### PR TITLE
Add buildscript for MacOSX and iOS

### DIFF
--- a/ios/0_build_everything.sh
+++ b/ios/0_build_everything.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ "$(uname)" != "Darwin" ]; then
+	echo "This buildscript requires MacOSX"
+	exit 1
+fi
+
+./1_download_library.sh \
+	&& ./2_build_toolchain.sh \
+	&& ./3_cleanup.sh

--- a/ios/1_download_library.sh
+++ b/ios/1_download_library.sh
@@ -36,48 +36,48 @@ rm -rf zlib-1.2.11/
 download_and_extract http://zlib.net/zlib-1.2.11.tar.gz
 
 # libpng
-rm -rf libpng-1.6.24/
-download_and_extract http://prdownloads.sourceforge.net/libpng/libpng-1.6.24.tar.xz
+rm -rf libpng-1.6.29/
+download_and_extract http://prdownloads.sourceforge.net/libpng/libpng-1.6.29.tar.xz
 
 # freetype
 rm -rf freetype-2.6.5/
 download_and_extract http://download.savannah.gnu.org/releases/freetype/freetype-2.6.5.tar.bz2
 
 # harfbuzz
-rm -rf harfbuzz-1.2.3/
-download_and_extract http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.2.3.tar.bz2
+rm -rf harfbuzz-1.3.2/
+download_and_extract http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.3.2.tar.bz2
 
 # pixman
 rm -rf pixman-0.34.0/
 download_and_extract http://cairographics.org/releases/pixman-0.34.0.tar.gz
 
 # expat
-rm -rf expat-2.2.0/
-download_and_extract http://sourceforge.net/projects/expat/files/expat/2.2.0/expat-2.2.0.tar.bz2
+rm -rf expat-2.2.1/
+download_and_extract http://sourceforge.net/projects/expat/files/expat/2.2.1/expat-2.2.1.tar.bz2
 
-# libogg 
+# libogg
 rm -rf libogg-1.3.2/
 download_and_extract http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.xz
 
-# libvorbis   
+# libvorbis
 rm -rf libvorbis-1.3.5/
 download_and_extract http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.xz
 
 # ICU
 rm -rf icu/
-download_and_extract http://download.icu-project.org/files/icu4c/58.1/icu4c-58_1-src.tgz
+download_and_extract http://download.icu-project.org/files/icu4c/59.1/icu4c-59_1-src.tgz
 
 # icudata
 rm -f icudt*.dat
 download_and_extract https://ci.easyrpg.org/job/icudata/lastSuccessfulBuild/artifact/icudata.tar.gz
 
 # mpg123
-rm -rf mpg123-1.23.6/
-download_and_extract http://www.mpg123.de/download/mpg123-1.23.6.tar.bz2
+rm -rf mpg123-1.25.0/
+download_and_extract http://www.mpg123.de/download/mpg123-1.25.0.tar.bz2
 
 # libsndfile
-rm -rf libsndfile-1.0.27/
-download_and_extract http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.27.tar.gz
+rm -rf libsndfile-1.0.28/
+download_and_extract http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28.tar.gz
 
 # libxmp-lite
 rm -rf libxmp-lite-4.4.1/
@@ -88,8 +88,8 @@ rm -rf speexdsp-1.2rc3/
 download_and_extract http://downloads.xiph.org/releases/speex/speexdsp-1.2rc3.tar.gz
 
 # wildmidi
-rm -rf wildmidi-wildmidi-0.4.0/
-download_and_extract https://github.com/Mindwerks/wildmidi/archive/wildmidi-0.4.0.tar.gz
+rm -rf wildmidi-wildmidi-0.4.1/
+download_and_extract https://github.com/Mindwerks/wildmidi/archive/wildmidi-0.4.1.tar.gz
 
 msg " [2] Downloading platform libraries"
 

--- a/ios/1_download_library.sh
+++ b/ios/1_download_library.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# abort on errors
+set -e
+
+export WORKSPACE=$PWD
+
+# helper
+function msg {
+	echo ""
+	echo $1
+}
+
+function download_and_extract {
+	url=$1
+	file=${url##*/}
+
+	msg "Downloading and extracting $file..."
+
+	wget -nv -N $url
+	tar xf $file
+}
+
+function git_clone {
+	url=$1
+	file=${url##*/}
+	msg "Cloning $file..."
+
+	git clone --depth=1 $url
+}
+
+msg " [1] Downloading generic libraries"
+
+# zlib
+rm -rf zlib-1.2.11/
+download_and_extract http://zlib.net/zlib-1.2.11.tar.gz
+
+# libpng
+rm -rf libpng-1.6.24/
+download_and_extract http://prdownloads.sourceforge.net/libpng/libpng-1.6.24.tar.xz
+
+# freetype
+rm -rf freetype-2.6.5/
+download_and_extract http://download.savannah.gnu.org/releases/freetype/freetype-2.6.5.tar.bz2
+
+# harfbuzz
+rm -rf harfbuzz-1.2.3/
+download_and_extract http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.2.3.tar.bz2
+
+# pixman
+rm -rf pixman-0.34.0/
+download_and_extract http://cairographics.org/releases/pixman-0.34.0.tar.gz
+
+# expat
+rm -rf expat-2.2.0/
+download_and_extract http://sourceforge.net/projects/expat/files/expat/2.2.0/expat-2.2.0.tar.bz2
+
+# libogg 
+rm -rf libogg-1.3.2/
+download_and_extract http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.xz
+
+# libvorbis   
+rm -rf libvorbis-1.3.5/
+download_and_extract http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.xz
+
+# ICU
+rm -rf icu/
+download_and_extract http://download.icu-project.org/files/icu4c/58.1/icu4c-58_1-src.tgz
+
+# icudata
+rm -f icudt*.dat
+download_and_extract https://ci.easyrpg.org/job/icudata/lastSuccessfulBuild/artifact/icudata.tar.gz
+
+# mpg123
+rm -rf mpg123-1.23.6/
+download_and_extract http://www.mpg123.de/download/mpg123-1.23.6.tar.bz2
+
+# libsndfile
+rm -rf libsndfile-1.0.27/
+download_and_extract http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.27.tar.gz
+
+# libxmp-lite
+rm -rf libxmp-lite-4.4.1/
+download_and_extract http://sourceforge.net/projects/xmp/files/libxmp/4.4.1/libxmp-lite-4.4.1.tar.gz
+
+# speexdsp
+rm -rf speexdsp-1.2rc3/
+download_and_extract http://downloads.xiph.org/releases/speex/speexdsp-1.2rc3.tar.gz
+
+# wildmidi
+rm -rf wildmidi-wildmidi-0.4.0/
+download_and_extract https://github.com/Mindwerks/wildmidi/archive/wildmidi-0.4.0.tar.gz
+
+msg " [2] Downloading platform libraries"
+
+# SDL
+rm -rf SDL2-2.0.5/
+download_and_extract https://www.libsdl.org/release/SDL2-2.0.5.tar.gz

--- a/ios/2_build_toolchain.sh
+++ b/ios/2_build_toolchain.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+
+if [ "$(uname)" != "Darwin" ]; then
+	echo "This buildscript requires MacOSX"
+	exit 1
+fi
+
+# abort on error
+set -e
+
+export WORKSPACE=$PWD
+
+export PLATFORM_PREFIX=$WORKSPACE
+export TARGET_HOST=arm-apple-darwin
+export PKG_CONFIG_PATH=$PLATFORM_PREFIX/lib/pkgconfig
+export PKG_CONFIG_LIBDIR=$PKG_CONFIG_PATH
+
+# Number of CPU
+NBPROC=$(getconf _NPROCESSORS_ONLN)
+
+# Use ccache?
+if [ -z ${NO_CCACHE+x} ]; then
+	if hash ccache >/dev/null 2>&1; then
+		ENABLE_CCACHE=1
+		echo "CCACHE enabled"
+	fi
+fi
+
+if [ ! -f .patches-applied ]; then
+	echo "patching libraries"
+
+	cp -r icu icu-native
+
+	# disable pixman examples and tests
+	cd pixman-0.34.0
+	perl -pi -e 's/SUBDIRS = pixman demos test/SUBDIRS = pixman/' Makefile.am
+	autoreconf -fi
+	cd ..
+
+	# disable png utils
+	cd libpng-1.6.24
+	perl -pi -e 's/^bin_PROGRAMS/# $&/' Makefile.am
+	autoreconf -fi
+	cd ..
+
+	# disable libsndfile examples and tests
+	cd libsndfile-1.0.27
+	perl -pi -e 's/ examples regtest tests programs//' Makefile.am
+	autoreconf -fi
+	cd ..
+
+	# Fix libxmp-lite compilation
+	patch -Np0 < libxmp-a0288352.patch
+
+	touch .patches-applied
+fi
+
+function set_build_flags {
+	CLANG=`xcodebuild -find clang`
+	CLANGXX=`xcodebuild -find clang++`
+	SDKPATH=`xcrun -sdk iphoneos10.2 --show-sdk-path`
+	ARCH="-arch armv7 -arch armv7s -arch arm64"
+
+	if [ "$ENABLE_CCACHE" ]; then
+		export CC="ccache $CLANG $ARCH"
+		export CXX="ccache $CLANGXX $ARCH"
+	else
+		export CC="$CLANG $ARCH"
+		export CXX="$CLANGXX $ARCH"
+	fi
+
+	export CPP="$CLANG -arch armv7 -E"
+	export CXXCPP="$CLANGXX -arch armv7 -E"
+
+	export CFLAGS="-I$WORKSPACE/include -g -O2 -miphoneos-version-min=7.0 -isysroot $SDKPATH -fobjc-arc"
+	export CPPFLAGS="$CFLAGS"
+	export CXXFLAGS="$CFLAGS"
+	export LDFLAGS="-L$WORKSPACE/lib $ARCH -miphoneos-version-min=7.0 -isysroot $SDKPATH"
+
+	if [ "$NBPROC" ]; then
+		export MAKEFLAGS="-j$NBPROC"
+	fi
+}
+
+# Default lib installer
+function install_lib {
+	echo ""
+	echo "**** Building ${1%-*} ****"
+	echo ""
+
+	cd $1
+	shift
+	./configure --host=$TARGET_HOST --prefix=$PLATFORM_PREFIX \
+		--disable-shared --enable-static $@
+	make clean
+	make
+	make install
+	cd ..
+
+	echo " -> done"
+}
+
+# Install zlib
+function install_lib_zlib {
+	echo ""
+	echo "**** Building zlib ****"
+	echo ""
+
+	cd zlib-1.2.11
+	CHOST=$TARGET_HOST ./configure --static --prefix=$PLATFORM_PREFIX
+	make clean
+	make
+	make install
+	cd ..
+
+	echo " -> done"
+}
+
+# Install ICU
+function install_lib_icu() {
+	echo ""
+	echo "**** Building ICU ****"
+	echo ""
+
+	# Compile native version
+	unset CC
+	unset CXX
+	unset CPP
+	unset CFLAGS
+	unset CPPFLAGS
+	unset CXXFLAGS
+	unset LDFLAGS
+
+	cp icudt58l.dat icu/source/data/in/
+	cp icudt58l.dat icu-native/source/data/in/
+	cd icu-native/source
+	perl -pi -e 's/SMALL_BUFFER_MAX_SIZE 512/SMALL_BUFFER_MAX_SIZE 2048/' tools/toolutil/pkg_genc.h
+	chmod u+x configure
+	./configure \
+		--enable-static --enable-shared=no --enable-tests=no --enable-samples=no \
+		--enable-dyload=no --enable-tools --enable-extras=no --enable-icuio=no \
+		--with-data-packaging=static
+	make
+	export ICU_CROSS_BUILD=$PWD
+
+	# Cross compile
+	set_build_flags
+
+	cd ../../icu/source
+
+	cp config/mh-linux config/mh-unknown
+
+	chmod u+x configure
+	./configure --host=$TARGET_HOST --with-cross-build=$ICU_CROSS_BUILD --enable-strict=no \
+		--enable-static --enable-shared=no --enable-tests=no --enable-samples=no --enable-dyload=no \
+		--enable-tools=no --enable-extras=no --enable-icuio=no \
+		--with-data-packaging=static --prefix=$PLATFORM_PREFIX
+	make clean
+	make
+	make install
+	cd ../..
+
+	echo " -> done"
+}
+
+function install_lib_wildmidi() {
+	echo ""
+	echo "**** Building WildMidi ****"
+	echo ""
+
+	cd wildmidi-wildmidi-0.4.0
+	cmake . -DCMAKE_SYSTEM_NAME=Generic -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWANT_PLAYER=OFF
+	make clean
+	make
+	cp include/wildmidi_lib.h $WORKSPACE/include
+	cp libWildMidi.a $WORKSPACE/lib
+	cd ..
+
+	echo " -> done"
+}
+
+function install_lib_sdl2() {
+	echo ""
+	echo "**** Building SDL2 ****"
+	echo ""
+
+	cd SDL2-2.0.5
+	./configure --host=$TARGET_HOST --prefix=$PLATFORM_PREFIX \
+		--disable-shared --enable-static
+	cp include/SDL_config_iphoneos.h include/SDL_config.h
+	make clean
+	make
+	make install
+	cd ..
+
+	echo " -> done"
+}
+
+# create needed directory structure
+mkdir -p bin include lib share
+
+set_build_flags
+# Install libraries
+install_lib_zlib
+install_lib libpng-1.6.24
+install_lib freetype-2.6.5 --with-harfbuzz=no --without-bzip2
+install_lib pixman-0.34.0
+install_lib expat-2.2.0
+install_lib libogg-1.3.2
+install_lib libvorbis-1.3.5
+install_lib_icu
+install_lib mpg123-1.23.6 --enable-fifo=no --enable-ipv6=no --enable-network=no \
+	--enable-int-quality=no --with-cpu=generic --with-default-audio=dummy
+install_lib libsndfile-1.0.27
+install_lib speexdsp-1.2rc3 --disable-neon
+install_lib_wildmidi
+install_lib libxmp-lite-4.4.1
+install_lib_sdl2
+
+# Post build steps
+# Allow detection of libxmp-lite as libxmp
+mv $WORKSPACE/lib/pkgconfig/libxmp-lite.pc $WORKSPACE/lib/pkgconfig/libxmp.pc

--- a/ios/2_build_toolchain.sh
+++ b/ios/2_build_toolchain.sh
@@ -38,13 +38,13 @@ if [ ! -f .patches-applied ]; then
 	cd ..
 
 	# disable png utils
-	cd libpng-1.6.24
+	cd libpng-1.6.29
 	perl -pi -e 's/^bin_PROGRAMS/# $&/' Makefile.am
 	autoreconf -fi
 	cd ..
 
 	# disable libsndfile examples and tests
-	cd libsndfile-1.0.27
+	cd libsndfile-1.0.28
 	perl -pi -e 's/ examples regtest tests programs//' Makefile.am
 	autoreconf -fi
 	cd ..
@@ -131,8 +131,8 @@ function install_lib_icu() {
 	unset CXXFLAGS
 	unset LDFLAGS
 
-	cp icudt58l.dat icu/source/data/in/
-	cp icudt58l.dat icu-native/source/data/in/
+	cp icudt59l.dat icu/source/data/in/
+	cp icudt59l.dat icu-native/source/data/in/
 	cd icu-native/source
 	perl -pi -e 's/SMALL_BUFFER_MAX_SIZE 512/SMALL_BUFFER_MAX_SIZE 2048/' tools/toolutil/pkg_genc.h
 	chmod u+x configure
@@ -168,7 +168,7 @@ function install_lib_wildmidi() {
 	echo "**** Building WildMidi ****"
 	echo ""
 
-	cd wildmidi-wildmidi-0.4.0
+	cd wildmidi-wildmidi-0.4.1
 	cmake . -DCMAKE_SYSTEM_NAME=Generic -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWANT_PLAYER=OFF
 	make clean
 	make
@@ -202,16 +202,18 @@ mkdir -p bin include lib share
 set_build_flags
 # Install libraries
 install_lib_zlib
-install_lib libpng-1.6.24
+install_lib libpng-1.6.29
 install_lib freetype-2.6.5 --with-harfbuzz=no --without-bzip2
+install_lib harfbuzz-1.3.2
+install_lib freetype-2.6.5 --with-harfbuzz=yes --without-bzip2
 install_lib pixman-0.34.0
-install_lib expat-2.2.0
+install_lib expat-2.2.1
 install_lib libogg-1.3.2
 install_lib libvorbis-1.3.5
 install_lib_icu
-install_lib mpg123-1.23.6 --enable-fifo=no --enable-ipv6=no --enable-network=no \
+install_lib mpg123-1.25.0 --enable-fifo=no --enable-ipv6=no --enable-network=no \
 	--enable-int-quality=no --with-cpu=generic --with-default-audio=dummy
-install_lib libsndfile-1.0.27
+install_lib libsndfile-1.0.28
 install_lib speexdsp-1.2rc3 --disable-neon
 install_lib_wildmidi
 install_lib libxmp-lite-4.4.1

--- a/ios/3_cleanup.sh
+++ b/ios/3_cleanup.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo
+echo "Cleaning up library build folders and other stuff..."
+
+rm -rf zlib-*/ freetype-*/ harfbuzz-*/ icu/ icu-native/ libpng-*/ expat-*/ pixman-*/ mpg123-*/ \
+	libsndfile-*/ libxmp-lite-*/ speexdsp-*/ wildmidi-*/ libogg-*/ libvorbis-*/ \
+	SDL2_mixer-*/ SDL2-*/
+rm -f *.bz2 *.gz *.xz *.tgz *.pl icudt* .patches-applied
+rm -rf bin/ share/ sbin/
+
+echo " -> done"

--- a/ios/3_cleanup.sh
+++ b/ios/3_cleanup.sh
@@ -5,8 +5,8 @@ echo "Cleaning up library build folders and other stuff..."
 
 rm -rf zlib-*/ freetype-*/ harfbuzz-*/ icu/ icu-native/ libpng-*/ expat-*/ pixman-*/ mpg123-*/ \
 	libsndfile-*/ libxmp-lite-*/ speexdsp-*/ wildmidi-*/ libogg-*/ libvorbis-*/ \
-	SDL2_mixer-*/ SDL2-*/
-rm -f *.bz2 *.gz *.xz *.tgz *.pl icudt* .patches-applied
+	SDL2-*/
+rm -f *.bz2 *.gz *.xz *.tgz icudt* .patches-applied
 rm -rf bin/ share/ sbin/
 
 echo " -> done"

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,3 +1,18 @@
 # EasyRPG buildscripts
 
-## iOS specifics
+## iOS Toolchain and libraries
+
+Requires MacOSX 10.12 or newer.
+
+Building requirements for MacOSX:
+
+ - XCode
+ - autotools
+ - pkg-config
+ - git
+ - cmake
+ - wget
+
+Local build process:
+
+Run `0_build_everything.sh` in a terminal

--- a/ios/libxmp-a0288352.patch
+++ b/ios/libxmp-a0288352.patch
@@ -1,0 +1,59 @@
+From a02883528979bbefc6d6d4be79d10b853e7b7041 Mon Sep 17 00:00:00 2001
+From: Carsten Teibes <dev@XXXX.de>
+Date: Sun, 6 Nov 2016 19:50:07 +0100
+Subject: [PATCH] Fix libxmp-lite building (wrong format loaders) Currently
+ trying to use the lite version fails with undefined references to the old
+ format loader names.
+
+This bug was introduced in d018decfb98d: "Add prefix to format loaders"
+---
+ lite/src/format.c           | 16 ++++++++--------
+ lite/src/loaders/mod_load.c |  2 +-
+ 2 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/lite/src/format.c b/lite/src/format.c
+index 277a3dac..e19f070e 100644
+--- libxmp-lite-4.4.1-old/src/format.c
++++ libxmp-lite-4.4.1/src/format.c
+@@ -27,20 +27,20 @@
+ #endif
+ #include "format.h"
+ 
+-extern const struct format_loader xm_loader;
+-extern const struct format_loader mod_loader;
+-extern const struct format_loader it_loader;
+-extern const struct format_loader s3m_loader;
++extern const struct format_loader libxmp_loader_xm;
++extern const struct format_loader libxmp_loader_mod;
++extern const struct format_loader libxmp_loader_it;
++extern const struct format_loader libxmp_loader_s3m;
+ 
+ extern const struct pw_format *const pw_format[];
+ 
+ const struct format_loader *const format_loader[5] = {
+-	&xm_loader,
+-	&mod_loader,
++	&libxmp_loader_xm,
++	&libxmp_loader_mod,
+ #ifndef LIBXMP_CORE_DISABLE_IT
+-	&it_loader,
++	&libxmp_loader_it,
+ #endif
+-	&s3m_loader,
++	&libxmp_loader_s3m,
+ 	NULL
+ };
+ 
+diff --git a/lite/src/loaders/mod_load.c b/lite/src/loaders/mod_load.c
+index b7a8f8de..bf72f36c 100644
+--- libxmp-lite-4.4.1-old/src/loaders/mod_load.c
++++ libxmp-lite-4.4.1/src/loaders/mod_load.c
+@@ -36,7 +36,7 @@
+ static int mod_test (HIO_HANDLE *, char *, const int);
+ static int mod_load (struct module_data *, HIO_HANDLE *, const int);
+ 
+-const struct format_loader mod_loader = {
++const struct format_loader libxmp_loader_mod = {
+     "Protracker",
+     mod_test,
+     mod_load

--- a/osx/0_build_everything.sh
+++ b/osx/0_build_everything.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ "$(uname)" != "Darwin" ]; then
+	echo "This buildscript requires MacOSX"
+	exit 1
+fi
+
+./1_download_library.sh \
+	&& ./2_build_toolchain.sh \
+	&& ./3_cleanup.sh

--- a/osx/1_download_library.sh
+++ b/osx/1_download_library.sh
@@ -36,48 +36,48 @@ rm -rf zlib-1.2.11/
 download_and_extract http://zlib.net/zlib-1.2.11.tar.gz
 
 # libpng
-rm -rf libpng-1.6.24/
-download_and_extract http://prdownloads.sourceforge.net/libpng/libpng-1.6.24.tar.xz
+rm -rf libpng-1.6.29/
+download_and_extract http://prdownloads.sourceforge.net/libpng/libpng-1.6.29.tar.xz
 
 # freetype
 rm -rf freetype-2.6.5/
 download_and_extract http://download.savannah.gnu.org/releases/freetype/freetype-2.6.5.tar.bz2
 
 # harfbuzz
-rm -rf harfbuzz-1.2.3/
-download_and_extract http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.2.3.tar.bz2
+rm -rf harfbuzz-1.3.2/
+download_and_extract http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.3.2.tar.bz2
 
 # pixman
 rm -rf pixman-0.34.0/
 download_and_extract http://cairographics.org/releases/pixman-0.34.0.tar.gz
 
 # expat
-rm -rf expat-2.2.0/
-download_and_extract http://sourceforge.net/projects/expat/files/expat/2.2.0/expat-2.2.0.tar.bz2
+rm -rf expat-2.2.1/
+download_and_extract http://sourceforge.net/projects/expat/files/expat/2.2.1/expat-2.2.1.tar.bz2
 
-# libogg 
+# libogg
 rm -rf libogg-1.3.2/
 download_and_extract http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.xz
 
-# libvorbis   
+# libvorbis
 rm -rf libvorbis-1.3.5/
 download_and_extract http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.xz
 
 # ICU
 rm -rf icu/
-download_and_extract http://download.icu-project.org/files/icu4c/58.1/icu4c-58_1-src.tgz
+download_and_extract http://download.icu-project.org/files/icu4c/59.1/icu4c-59_1-src.tgz
 
 # icudata
 rm -f icudt*.dat
 download_and_extract https://ci.easyrpg.org/job/icudata/lastSuccessfulBuild/artifact/icudata.tar.gz
 
 # mpg123
-rm -rf mpg123-1.23.6/
-download_and_extract http://www.mpg123.de/download/mpg123-1.23.6.tar.bz2
+rm -rf mpg123-1.25.0/
+download_and_extract http://www.mpg123.de/download/mpg123-1.25.0.tar.bz2
 
 # libsndfile
-rm -rf libsndfile-1.0.27/
-download_and_extract http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.27.tar.gz
+rm -rf libsndfile-1.0.28/
+download_and_extract http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28.tar.gz
 
 # libxmp-lite
 rm -rf libxmp-lite-4.4.1/
@@ -88,8 +88,8 @@ rm -rf speexdsp-1.2rc3/
 download_and_extract http://downloads.xiph.org/releases/speex/speexdsp-1.2rc3.tar.gz
 
 # wildmidi
-rm -rf wildmidi-wildmidi-0.4.0/
-download_and_extract https://github.com/Mindwerks/wildmidi/archive/wildmidi-0.4.0.tar.gz
+rm -rf wildmidi-wildmidi-0.4.1/
+download_and_extract https://github.com/Mindwerks/wildmidi/archive/wildmidi-0.4.1.tar.gz
 
 msg " [2] Downloading platform libraries"
 

--- a/osx/1_download_library.sh
+++ b/osx/1_download_library.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# abort on errors
+set -e
+
+export WORKSPACE=$PWD
+
+# helper
+function msg {
+	echo ""
+	echo $1
+}
+
+function download_and_extract {
+	url=$1
+	file=${url##*/}
+
+	msg "Downloading and extracting $file..."
+
+	wget -nv -N $url
+	tar xf $file
+}
+
+function git_clone {
+	url=$1
+	file=${url##*/}
+	msg "Cloning $file..."
+
+	git clone --depth=1 $url
+}
+
+msg " [1] Downloading generic libraries"
+
+# zlib
+rm -rf zlib-1.2.11/
+download_and_extract http://zlib.net/zlib-1.2.11.tar.gz
+
+# libpng
+rm -rf libpng-1.6.24/
+download_and_extract http://prdownloads.sourceforge.net/libpng/libpng-1.6.24.tar.xz
+
+# freetype
+rm -rf freetype-2.6.5/
+download_and_extract http://download.savannah.gnu.org/releases/freetype/freetype-2.6.5.tar.bz2
+
+# harfbuzz
+rm -rf harfbuzz-1.2.3/
+download_and_extract http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.2.3.tar.bz2
+
+# pixman
+rm -rf pixman-0.34.0/
+download_and_extract http://cairographics.org/releases/pixman-0.34.0.tar.gz
+
+# expat
+rm -rf expat-2.2.0/
+download_and_extract http://sourceforge.net/projects/expat/files/expat/2.2.0/expat-2.2.0.tar.bz2
+
+# libogg 
+rm -rf libogg-1.3.2/
+download_and_extract http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.xz
+
+# libvorbis   
+rm -rf libvorbis-1.3.5/
+download_and_extract http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.xz
+
+# ICU
+rm -rf icu/
+download_and_extract http://download.icu-project.org/files/icu4c/58.1/icu4c-58_1-src.tgz
+
+# icudata
+rm -f icudt*.dat
+download_and_extract https://ci.easyrpg.org/job/icudata/lastSuccessfulBuild/artifact/icudata.tar.gz
+
+# mpg123
+rm -rf mpg123-1.23.6/
+download_and_extract http://www.mpg123.de/download/mpg123-1.23.6.tar.bz2
+
+# libsndfile
+rm -rf libsndfile-1.0.27/
+download_and_extract http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.27.tar.gz
+
+# libxmp-lite
+rm -rf libxmp-lite-4.4.1/
+download_and_extract http://sourceforge.net/projects/xmp/files/libxmp/4.4.1/libxmp-lite-4.4.1.tar.gz
+
+# speexdsp
+rm -rf speexdsp-1.2rc3/
+download_and_extract http://downloads.xiph.org/releases/speex/speexdsp-1.2rc3.tar.gz
+
+# wildmidi
+rm -rf wildmidi-wildmidi-0.4.0/
+download_and_extract https://github.com/Mindwerks/wildmidi/archive/wildmidi-0.4.0.tar.gz
+
+msg " [2] Downloading platform libraries"
+
+# SDL
+rm -rf SDL2-2.0.5/
+download_and_extract https://www.libsdl.org/release/SDL2-2.0.5.tar.gz
+
+# SDL mixer
+rm -rf SDL_mixer-2.0.1/
+download_and_extract https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.1.tar.gz

--- a/osx/2_build_toolchain.sh
+++ b/osx/2_build_toolchain.sh
@@ -35,16 +35,25 @@ if [ ! -f .patches-applied ]; then
 	cd ..
 
 	# disable png utils
-	cd libpng-1.6.24
+	cd libpng-1.6.29
 	perl -pi -e 's/^bin_PROGRAMS/# $&/' Makefile.am
 	autoreconf -fi
 	cd ..
 
-        # disable SDL2 mixer examples
+	# disable libsndfile examples and tests
+	cd libsndfile-1.0.28
+	perl -pi -e 's/ examples regtest tests programs//' Makefile.am
+	autoreconf -fi
+	cd ..
+
+	# disable SDL2 mixer examples
 	patch -Np0 < SDL2_mixer.patch
 	cd SDL2_mixer-2.0.1
 	autoreconf -fi
 	cd ..
+
+	# Fix expat 2.2.1 compilation on MacOSX
+	patch -Np0 < expat-2.2.1-osx.patch
 
 	# Fix libxmp-lite compilation
 	patch -Np0 < libxmp-a0288352.patch
@@ -120,7 +129,7 @@ function install_lib_icu() {
 	echo ""
 
 	# No crosscompile needed. Runs native on this platform
-	cp icudt58l.dat icu/source/data/in/
+	cp icudt59l.dat icu/source/data/in/
 	cd icu/source
 	perl -pi -e 's/SMALL_BUFFER_MAX_SIZE 512/SMALL_BUFFER_MAX_SIZE 2048/' tools/toolutil/pkg_genc.h
 	chmod u+x configure
@@ -142,7 +151,7 @@ function install_lib_wildmidi() {
 	echo "**** Building WildMidi ****"
 	echo ""
 
-	cd wildmidi-wildmidi-0.4.0
+	cd wildmidi-wildmidi-0.4.1
 	cmake . -DCMAKE_SYSTEM_NAME=Generic -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWANT_PLAYER=OFF
 	make clean
 	make
@@ -159,16 +168,18 @@ mkdir -p bin include lib share
 set_build_flags
 # Install libraries
 install_lib_zlib
-install_lib libpng-1.6.24
+install_lib libpng-1.6.29
 install_lib freetype-2.6.5 --with-harfbuzz=no --without-bzip2
+install_lib harfbuzz-1.3.2
+install_lib freetype-2.6.5 --with-harfbuzz=yes --without-bzip2
 install_lib pixman-0.34.0
-install_lib expat-2.2.0
+install_lib expat-2.2.1
 install_lib libogg-1.3.2
 install_lib libvorbis-1.3.5
 install_lib_icu
-install_lib mpg123-1.23.6 --enable-fifo=no --enable-ipv6=no --enable-network=no \
+install_lib mpg123-1.25.0 --enable-fifo=no --enable-ipv6=no --enable-network=no \
 	--enable-int-quality=no --with-cpu=generic --with-default-audio=dummy
-install_lib libsndfile-1.0.27
+install_lib libsndfile-1.0.28
 install_lib speexdsp-1.2rc3
 install_lib_wildmidi
 install_lib libxmp-lite-4.4.1

--- a/osx/2_build_toolchain.sh
+++ b/osx/2_build_toolchain.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+if [ "$(uname)" != "Darwin" ]; then
+	echo "This buildscript requires MacOSX"
+	exit 1
+fi
+
+# abort on error
+set -e
+
+export WORKSPACE=$PWD
+
+export PLATFORM_PREFIX=$WORKSPACE
+export PKG_CONFIG_PATH=$PLATFORM_PREFIX/lib/pkgconfig
+export PKG_CONFIG_LIBDIR=$PKG_CONFIG_PATH
+
+# Number of CPU
+NBPROC=$(getconf _NPROCESSORS_ONLN)
+
+# Use ccache?
+if [ -z ${NO_CCACHE+x} ]; then
+	if hash ccache >/dev/null 2>&1; then
+		ENABLE_CCACHE=1
+		echo "CCACHE enabled"
+	fi
+fi
+
+if [ ! -f .patches-applied ]; then
+	echo "patching libraries"
+
+	# disable pixman examples and tests
+	cd pixman-0.34.0
+	perl -pi -e 's/SUBDIRS = pixman demos test/SUBDIRS = pixman/' Makefile.am
+	autoreconf -fi
+	cd ..
+
+	# disable png utils
+	cd libpng-1.6.24
+	perl -pi -e 's/^bin_PROGRAMS/# $&/' Makefile.am
+	autoreconf -fi
+	cd ..
+
+        # disable SDL2 mixer examples
+	patch -Np0 < SDL2_mixer.patch
+	cd SDL2_mixer-2.0.1
+	autoreconf -fi
+	cd ..
+
+	# Fix libxmp-lite compilation
+	patch -Np0 < libxmp-a0288352.patch
+
+	touch .patches-applied
+fi
+
+function set_build_flags {
+	CLANG=`xcodebuild -find clang`
+	CLANGXX=`xcodebuild -find clang++`
+	ARCH="-arch i386 -arch x86_64"
+	SDKPATH=`xcrun -sdk macosx10.12 --show-sdk-path`
+
+	if [ "$ENABLE_CCACHE" ]; then
+		export CC="ccache $CLANG $ARCH"
+		export CXX="ccache $CLANGXX $ARCH"
+	else
+		export CC="$CLANG $ARCH"
+		export CXX="$CLANGXX $ARCH"
+	fi
+
+	export CPP="$CLANG -arch i386 -E"
+	export CXXCPP="$CLANGXX -arch i386 -E"
+
+	export CFLAGS="-I$WORKSPACE/include -g -O2 -mmacosx-version-min=10.9 -isysroot $SDKPATH"
+	export CPPFLAGS="$CFLAGS"
+	export CXXFLAGS="$CFLAGS"
+	export LDFLAGS="-L$WORKSPACE/lib $ARCH -mmacosx-version-min=10.9 -isysroot $SDKPATH"
+
+	if [ "$NBPROC" ]; then
+		export MAKEFLAGS="-j$NBPROC"
+	fi
+}
+
+# Default lib installer
+function install_lib {
+	echo ""
+	echo "**** Building ${1%-*} ****"
+	echo ""
+
+	cd $1
+	shift
+	./configure --prefix=$PLATFORM_PREFIX \
+		--disable-shared --enable-static $@
+	make clean
+	make
+	make install
+	cd ..
+
+	echo " -> done"
+}
+
+# Install zlib
+function install_lib_zlib {
+	echo ""
+	echo "**** Building zlib ****"
+	echo ""
+
+	cd zlib-1.2.11
+	./configure --static --prefix=$PLATFORM_PREFIX
+	make clean
+	make
+	make install
+	cd ..
+
+	echo " -> done"
+}
+
+# Install ICU
+function install_lib_icu() {
+	echo ""
+	echo "**** Building ICU ****"
+	echo ""
+
+	# No crosscompile needed. Runs native on this platform
+	cp icudt58l.dat icu/source/data/in/
+	cd icu/source
+	perl -pi -e 's/SMALL_BUFFER_MAX_SIZE 512/SMALL_BUFFER_MAX_SIZE 2048/' tools/toolutil/pkg_genc.h
+	chmod u+x configure
+	./configure --enable-strict=no \
+		--enable-static --enable-shared=no --enable-tests=no --enable-samples=no --enable-dyload=no \
+		--enable-tools=yes --enable-extras=no --enable-icuio=no \
+		--with-data-packaging=static --prefix=$PLATFORM_PREFIX
+
+	make clean
+	make
+	make install
+	cd ../..
+
+	echo " -> done"
+}
+
+function install_lib_wildmidi() {
+	echo ""
+	echo "**** Building WildMidi ****"
+	echo ""
+
+	cd wildmidi-wildmidi-0.4.0
+	cmake . -DCMAKE_SYSTEM_NAME=Generic -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWANT_PLAYER=OFF
+	make clean
+	make
+	cp include/wildmidi_lib.h $WORKSPACE/include
+	cp libWildMidi.a $WORKSPACE/lib
+	cd ..
+
+	echo " -> done"
+}
+
+# create needed directory structure
+mkdir -p bin include lib share
+
+set_build_flags
+# Install libraries
+install_lib_zlib
+install_lib libpng-1.6.24
+install_lib freetype-2.6.5 --with-harfbuzz=no --without-bzip2
+install_lib pixman-0.34.0
+install_lib expat-2.2.0
+install_lib libogg-1.3.2
+install_lib libvorbis-1.3.5
+install_lib_icu
+install_lib mpg123-1.23.6 --enable-fifo=no --enable-ipv6=no --enable-network=no \
+	--enable-int-quality=no --with-cpu=generic --with-default-audio=dummy
+install_lib libsndfile-1.0.27
+install_lib speexdsp-1.2rc3
+install_lib_wildmidi
+install_lib libxmp-lite-4.4.1
+install_lib SDL2-2.0.5
+install_lib SDL2_mixer-2.0.1 --disable-sdltest --disable-music-ogg --disable-music-flac \
+	--disable-music-midi-fluidsynth --disable-music-midi-fluidsynth-shared \
+	--disable-music-mod --disable-music-mp3
+
+# Post build steps
+# Allow detection of libxmp-lite as libxmp
+mv $WORKSPACE/lib/pkgconfig/libxmp-lite.pc $WORKSPACE/lib/pkgconfig/libxmp.pc

--- a/osx/3_cleanup.sh
+++ b/osx/3_cleanup.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo
+echo "Cleaning up library build folders and other stuff..."
+
+rm -rf zlib-*/ freetype-*/ harfbuzz-*/ icu/ icu-native/ libpng-*/ expat-*/ pixman-*/ mpg123-*/ \
+	libsndfile-*/ libxmp-lite-*/ speexdsp-*/ wildmidi-*/ libogg-*/ libvorbis-*/ \
+	SDL2_mixer-*/ SDL2-*/
+rm -f *.bz2 *.gz *.xz *.tgz *.pl icudt* .patches-applied
+rm -rf bin/ share/ sbin/
+
+echo " -> done"

--- a/osx/3_cleanup.sh
+++ b/osx/3_cleanup.sh
@@ -6,7 +6,7 @@ echo "Cleaning up library build folders and other stuff..."
 rm -rf zlib-*/ freetype-*/ harfbuzz-*/ icu/ icu-native/ libpng-*/ expat-*/ pixman-*/ mpg123-*/ \
 	libsndfile-*/ libxmp-lite-*/ speexdsp-*/ wildmidi-*/ libogg-*/ libvorbis-*/ \
 	SDL2_mixer-*/ SDL2-*/
-rm -f *.bz2 *.gz *.xz *.tgz *.pl icudt* .patches-applied
+rm -f *.bz2 *.gz *.xz *.tgz icudt* .patches-applied
 rm -rf bin/ share/ sbin/
 
 echo " -> done"

--- a/osx/README.md
+++ b/osx/README.md
@@ -1,3 +1,18 @@
 # EasyRPG buildscripts
 
-## OS X specifics
+## MacOSX Toolchain and libraries
+
+Requires MacOSX 10.12 or newer.
+
+Building requirements for MacOSX:
+
+ - XCode
+ - autotools
+ - pkg-config
+ - git
+ - cmake
+ - wget
+
+Local build process:
+
+Run `0_build_everything.sh` in a terminal

--- a/osx/SDL2_mixer.patch
+++ b/osx/SDL2_mixer.patch
@@ -1,0 +1,20 @@
+diff -Naur SDL2_mixer-2.0.1-orig/Makefile.in SDL2_mixer-2.0.1/Makefile.in
+--- SDL2_mixer-2.0.1-orig/Makefile.in	2017-06-19 07:03:31.000000000 -0600
++++ SDL2_mixer-2.0.1/Makefile.in	2017-06-19 07:04:06.000000000 -0600
+@@ -47,7 +47,7 @@
+ LT_REVISION = @LT_REVISION@
+ LT_LDFLAGS  = -no-undefined -rpath $(libdir) -release $(LT_RELEASE) -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
+ 
+-all: $(srcdir)/configure Makefile $(objects) $(objects)/$(TARGET) $(objects)/playwave$(EXE) $(objects)/playmus$(EXE)
++all: $(srcdir)/configure Makefile $(objects) $(objects)/$(TARGET)
+ 
+ $(srcdir)/configure: $(srcdir)/configure.in
+ 	@echo "Warning, configure.in is out of date"
+diff -Naur SDL2_mixer-2.0.1-orig/configure.in SDL2_mixer-2.0.1/configure.in
+--- SDL2_mixer-2.0.1-orig/configure.in	2017-06-19 07:03:25.000000000 -0600
++++ SDL2_mixer-2.0.1/configure.in	2017-06-19 07:04:05.000000000 -0600
+@@ -1,3 +1,4 @@
++AC_CONFIG_MACRO_DIRS([acinclude])
+ dnl Process this file with autoconf to produce a configure script.
+ AC_INIT(README.txt)
+ AC_CONFIG_AUX_DIR(build-scripts)

--- a/osx/expat-2.2.1-osx.patch
+++ b/osx/expat-2.2.1-osx.patch
@@ -1,0 +1,13 @@
+diff -Naur expat-2.2.1-orig/lib/xmlparse.c expat-2.2.1/lib/xmlparse.c
+--- expat-2.2.1-orig/lib/xmlparse.c	2017-06-20 07:22:55.000000000 -0600
++++ expat-2.2.1/lib/xmlparse.c	2017-06-20 07:23:24.000000000 -0600
+@@ -699,7 +699,9 @@
+ # include <errno.h>
+ 
+ # if defined(HAVE_GETRANDOM)
++#undef buffer
+ #  include <sys/random.h>    /* getrandom */
++#define buffer (parser->m_buffer) 
+ # else
+ #  include <unistd.h>        /* syscall */
+ #  include <sys/syscall.h>   /* SYS_getrandom */

--- a/osx/libxmp-a0288352.patch
+++ b/osx/libxmp-a0288352.patch
@@ -1,0 +1,59 @@
+From a02883528979bbefc6d6d4be79d10b853e7b7041 Mon Sep 17 00:00:00 2001
+From: Carsten Teibes <dev@XXXX.de>
+Date: Sun, 6 Nov 2016 19:50:07 +0100
+Subject: [PATCH] Fix libxmp-lite building (wrong format loaders) Currently
+ trying to use the lite version fails with undefined references to the old
+ format loader names.
+
+This bug was introduced in d018decfb98d: "Add prefix to format loaders"
+---
+ lite/src/format.c           | 16 ++++++++--------
+ lite/src/loaders/mod_load.c |  2 +-
+ 2 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/lite/src/format.c b/lite/src/format.c
+index 277a3dac..e19f070e 100644
+--- libxmp-lite-4.4.1-old/src/format.c
++++ libxmp-lite-4.4.1/src/format.c
+@@ -27,20 +27,20 @@
+ #endif
+ #include "format.h"
+ 
+-extern const struct format_loader xm_loader;
+-extern const struct format_loader mod_loader;
+-extern const struct format_loader it_loader;
+-extern const struct format_loader s3m_loader;
++extern const struct format_loader libxmp_loader_xm;
++extern const struct format_loader libxmp_loader_mod;
++extern const struct format_loader libxmp_loader_it;
++extern const struct format_loader libxmp_loader_s3m;
+ 
+ extern const struct pw_format *const pw_format[];
+ 
+ const struct format_loader *const format_loader[5] = {
+-	&xm_loader,
+-	&mod_loader,
++	&libxmp_loader_xm,
++	&libxmp_loader_mod,
+ #ifndef LIBXMP_CORE_DISABLE_IT
+-	&it_loader,
++	&libxmp_loader_it,
+ #endif
+-	&s3m_loader,
++	&libxmp_loader_s3m,
+ 	NULL
+ };
+ 
+diff --git a/lite/src/loaders/mod_load.c b/lite/src/loaders/mod_load.c
+index b7a8f8de..bf72f36c 100644
+--- libxmp-lite-4.4.1-old/src/loaders/mod_load.c
++++ libxmp-lite-4.4.1/src/loaders/mod_load.c
+@@ -36,7 +36,7 @@
+ static int mod_test (HIO_HANDLE *, char *, const int);
+ static int mod_load (struct module_data *, HIO_HANDLE *, const int);
+ 
+-const struct format_loader mod_loader = {
++const struct format_loader libxmp_loader_mod = {
+     "Protracker",
+     mod_test,
+     mod_load


### PR DESCRIPTION
Requires MacOSX, no osxcross support

This PR is mostly for discussion. The build_easyrpg.sh is just a reference for Jenkins, will remove it later.

The toolchains are already placed where the Jenkins job would put them ($JENKINS/ios-toolchain/ios and $JENKINS/osx-toolchain/osx) for playing around.