### PR TITLE
Windows: Update ICU patch to latest version

### DIFF
--- a/windows/build.cmd
+++ b/windows/build.cmd
@@ -20,10 +20,12 @@ xcopy /Y /I /E ..\icu-easyrpg ports\icu-easyrpg
 vcpkg install --triplet x86-windows-static^
  libpng[core] expat[core] pixman[core] harfbuzz[core,ucdn] libvorbis[core]^
  libsndfile[core] wildmidi[core] libxmp-lite[core] speexdsp[core]^
- opusfile[core] sdl2-image[core] sdl2-mixer[core] icu-easyrpg[core]
+ mpg123[core] opusfile[core] sdl2-image[core] sdl2-mixer[core]^
+ icu-easyrpg[core]
 
 :: Build 64-bit libraries
 vcpkg install --triplet x64-windows-static^
  libpng[core] expat[core] pixman[core] harfbuzz[core,ucdn] libvorbis[core]^
  libsndfile[core] wildmidi[core] libxmp-lite[core] speexdsp[core]^
- opusfile[core] sdl2-image[core] sdl2-mixer[core] icu-easyrpg[core]
+ mpg123[core] opusfile[core] sdl2-image[core] sdl2-mixer[core]^
+ icu-easyrpg[core]

--- a/windows/icu-easyrpg/fix_parallel_build_on_windows.patch
+++ b/windows/icu-easyrpg/fix_parallel_build_on_windows.patch
@@ -1,0 +1,13 @@
+diff --git a/source/data/Makefile.in b/source/data/Makefile.in
+index 1140b69..936ef81 100644
+--- a/source/data/Makefile.in
++++ b/source/data/Makefile.in
+@@ -514,7 +514,7 @@ build-dir:
+ # The | is an order-only prerequisite. This helps when the -j option is used,
+ # and we don't want the files to be built before the directories are built.
+ ifneq ($(filter order-only,$(.FEATURES)),)
+-$(ALL_FILES) $(ALL_INDEX_SRC_FILES): | build-dir
++$(ALL_FILES) $(ALL_INDEX_SRC_FILES) $(SO_VERSION_DATA): | build-dir
+ endif
+ 
+ # Now, sections for building each kind of data.


### PR DESCRIPTION
Upstream vcpkg is still on 61.1 but they changed how the extract command works.
Updated to the portfile from latest vcpkg and fixed extract location for our custom data file.

Confirmed working already on the buildbot.