### PR TITLE
Android: Update to latest SDK installer. Drop armeabi, add x86_64

### DIFF
--- a/android/1_download_library.sh
+++ b/android/1_download_library.sh
@@ -32,15 +32,16 @@ if [ $os = "Linux" ]; then
 	SDK_PLATFORM=linux
 # MacOS
 elif [ $os = "Darwin" ]; then
-	SDK_PLATFORM=darwin
+	SDK_PLATFORM=mac
 else
 	msg "Only Linux and macOS are supported currently. Sorry! :("
 	exit 1
 fi
 
-SDK_URL="https://dl.google.com/android/repository/sdk-tools-${SDK_PLATFORM}-3859397.zip"
+SDK_VERSION="6200805_latest"
+SDK_URL="https://dl.google.com/android/repository/commandlinetools-${SDK_PLATFORM}-${SDK_VERSION}.zip"
 download $SDK_URL
-unzip sdk-tools-${SDK_PLATFORM}-3859397.zip
+unzip commandlinetools-${SDK_PLATFORM}-${SDK_VERSION}.zip
 mv tools android-sdk
 
 PATH=$PATH:$WORKSPACE/android-sdk

--- a/android/2_build_toolchain.sh
+++ b/android/2_build_toolchain.sh
@@ -35,7 +35,7 @@ fi
 
 # Install SDL2
 function install_lib_sdl {
-	# $1: platform (armeabi armeabi-v7a x86 aarch64)
+	# $1: platform (armeabi-v7a aarch64 x86 x86_x64)
 
 	pushd $SDL2_DIR
 	echo "APP_ABI := $1" >> "jni/Application.mk"
@@ -61,6 +61,10 @@ function build() {
 	export TARGET_API=14
 	if [ "$3" = "arm64" ]; then
 		# Minimum API 21 on ARM64
+		export TARGET_API=21
+	fi
+	if [ "$3" = "x86_64" ]; then
+		# Minimum API 21 on x86_64
 		export TARGET_API=21
 	fi
 
@@ -122,14 +126,14 @@ install_lib_icu_native
 # Correctly detected mmap support in mpg123
 export ac_cv_func_mmap_fixed_mapped=yes
 
-# Install standalone toolchain x86
-build "x86" "x86" "x86" "i686-linux-android" ""
-
-# Install standalone toolchain ARMeabi
-build "ARMeabi" "armeabi" "arm" "arm-linux-androideabi" ""
-
 # Install standalone toolchain ARMeabi-v7a
 build "ARMeabi-v7a" "armeabi-v7a" "arm" "arm-linux-androideabi" "-march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3"
 
 # Install standalone toolchain arm64-v8a
 build "AArch64" "arm64-v8a" "arm64" "aarch64-linux-android" ""
+
+# Install standalone toolchain x86
+build "x86" "x86" "x86" "i686-linux-android" ""
+
+# Install standalone toolchain x86_64
+build "x86_64" "x86_64" "x86_64" "x86_64-linux-android" ""

--- a/android/4_build_liblcf.sh
+++ b/android/4_build_liblcf.sh
@@ -72,7 +72,8 @@ msg " -> done"
 cd ..
 
 # Compile liblcf
-build "x86" "x86" "i686-linux-android" ""
-build "ARMeabi" "armeabi" "arm-linux-androideabi" ""
 build "ARMeabi-v7a" "armeabi-v7a" "arm-linux-androideabi" "-march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3"
 build "AArch64" "arm64-v8a" "aarch64-linux-android" ""
+build "x86" "x86" "i686-linux-android" ""
+build "x86_64" "x86_64" "x86_64-linux-android" ""
+

--- a/shared/packages.sh
+++ b/shared/packages.sh
@@ -109,7 +109,7 @@ ICUDATA_URL=https://ci.easyrpg.org/job/icudata/lastSuccessfulBuild/artifact/icud
 ICUDATA_FILES=icudt*.dat
 
 lib=SDL2
-ver=2.0.9
+ver=2.0.12
 SDL2_URL="https://libsdl.org/release/$lib-$ver.tar.gz"
 SDL2_DIR="$lib-$ver"
 
@@ -124,7 +124,7 @@ SDL2_MIXER_ARGS="--with-sdl-prefix=$WORKSPACE --disable-music-ogg \
 
 # only needed for lmu2png tool
 lib=SDL2_image
-ver=2.0.1
+ver=2.0.5
 SDL2_IMAGE_URL="https://www.libsdl.org/projects/SDL_image/release/$lib-$ver.tar.gz"
 SDL2_IMAGE_DIR="$lib-$ver"
 SDL2_IMAGE_ARGS="--disable-jpg --disable-png-shared --disable-tif --disable-webp"


### PR DESCRIPTION
SDL library updates.

The new SDK runs with Java 13 (old one failed already on Java 9). Though the gradle wrapper we bundle with Player is still Java 8 only.

Lets hope that the "6200805_latest.zip" URL stays valid and that they dont drop "latest" when there is a new release ^^'.