### PR TITLE
Vcpkg:  Add Freetype[core]. Prevents the build of bzip2.

### DIFF
--- a/windows/build.cmd
+++ b/windows/build.cmd
@@ -18,14 +18,14 @@ xcopy /Y /I /E ..\icu-easyrpg ports\icu-easyrpg
 :: Using [core] everywhere to prevent surprises when new default-features are
 :: added to libraries.
 vcpkg install --triplet x86-windows-static^
- libpng[core] expat[core] pixman[core] harfbuzz[core,ucdn] libvorbis[core]^
- libsndfile[core] wildmidi[core] libxmp-lite[core] speexdsp[core]^
- mpg123[core] opusfile[core] sdl2-image[core] sdl2-mixer[core]^
+ libpng[core] expat[core] pixman[core] freetype[core] harfbuzz[core,ucdn]^
+ libvorbis[core]^ libsndfile[core] wildmidi[core] libxmp-lite[core]^
+ speexdsp[core] mpg123[core] opusfile[core] sdl2-image[core] sdl2-mixer[core]^
  icu-easyrpg[core]
 
 :: Build 64-bit libraries
 vcpkg install --triplet x64-windows-static^
- libpng[core] expat[core] pixman[core] harfbuzz[core,ucdn] libvorbis[core]^
- libsndfile[core] wildmidi[core] libxmp-lite[core] speexdsp[core]^
- mpg123[core] opusfile[core] sdl2-image[core] sdl2-mixer[core]^
+ libpng[core] expat[core] pixman[core] freetype[core] harfbuzz[core,ucdn]^
+ libvorbis[core]^ libsndfile[core] wildmidi[core] libxmp-lite[core]^
+ speexdsp[core] mpg123[core] opusfile[core] sdl2-image[core] sdl2-mixer[core]^
  icu-easyrpg[core]


### PR DESCRIPTION
Freetype learned feature selection a while ago, so we can get rid of bzip2 :)