### PR TITLE
Update ICU download links

### DIFF
--- a/emscripten/packages.sh
+++ b/emscripten/packages.sh
@@ -1,3 +1,3 @@
 lib=ICU
-ver=60.2
-ICU_URL=http://download.icu-project.org/files/icu4c/$ver/icu4c-${ver/./_}-src.tgz
+ver=60.3
+ICU_URL=https://github.com/unicode-org/icu/releases/download/release-${ver//./-}/icu4c-${ver//./_}-src.tgz

--- a/shared/packages.sh
+++ b/shared/packages.sh
@@ -97,8 +97,8 @@ OPUSFILE_DIR="$lib-$ver"
 OPUSFILE_ARGS="--disable-http"
 
 lib=ICU
-ver=59.1
-ICU_URL=http://download.icu-project.org/files/icu4c/$ver/icu4c-${ver//./_}-src.tgz
+ver=59.2
+ICU_URL=https://github.com/unicode-org/icu/releases/download/release-${ver//./-}/icu4c-${ver//./_}-src.tgz
 ICU_DIR="icu"
 ICU_ARGS="--enable-strict=no --disable-tests --disable-samples \
 	--disable-dyload --disable-extras --disable-icuio \

--- a/wii/packages.sh
+++ b/wii/packages.sh
@@ -1,6 +1,6 @@
 lib=ICU
-ver=58.1
-ICU_URL=http://download.icu-project.org/files/icu4c/$ver/icu4c-${ver/./_}-src.tgz
+ver=58.3
+ICU_URL=https://github.com/unicode-org/icu/releases/download/release-${ver//./-}/icu4c-${ver//./_}-src.tgz
 
 lib=sdl-wii
 ver=2018-08-31


### PR DESCRIPTION
Use latest maintenance releases, as older ones are not hosted anymore.

ICU site does not host them anymore since some days.