### PR TITLE
Linux: Convince SDL2 to enable dynamic pulseaudio library

### DIFF
--- a/linux-static/2_build_toolchain.sh
+++ b/linux-static/2_build_toolchain.sh
@@ -56,6 +56,6 @@ install_lib_cmake $WILDMIDI_DIR $WILDMIDI_ARGS
 install_lib $OPUS_DIR $OPUS_ARGS
 install_lib $OPUSFILE_DIR $OPUSFILE_ARGS
 install_lib $ICU_DIR/source $ICU_ARGS
-install_lib $SDL2_DIR $SDL2_ARGS
+install_lib $SDL2_DIR $SDL2_ARGS PULSEAUDIO_CFLAGS=-Ixxxdir PULSEAUDIO_LIBS=-lxxxlib
 install_lib $SDL2_MIXER_DIR $SDL2_MIXER_ARGS
 install_lib $SDL2_IMAGE_DIR $SDL2_IMAGE_ARGS


### PR DESCRIPTION
Guess that's a bit of a hack :)

SDL2 semi-ignores PKG_CONFIG_LIBDIR because it supports dynamic loading. It scans the file system for library files directly by asking gcc for default directories..............

E.g. when alsa-dev is installed on the host SDL2 will always enable dynamic loading of Alsa.

Same trick can be used / abused to get pulseaudio (dynamic) on, just need to pass a pkg-config check. Only the header is needed (is in /usr/include). The library is never used.

```
Audio drivers   : disk dummy oss alsa(dynamic) pulse(dynamic)
```

Proof that the libs are dynamic. No dependencies on them.

```
objdump -r libSDL2.a | grep "pulse"
SDL_pulseaudio.o:     file format elf64-x86-64
000000000000000a R_X86_64_PC32     .bss.pulseaudio_handle-0x0000000000000004
[...]
000000000000003c R_X86_64_PC32     .text.load_pulseaudio_sym-0x0000000000000004

cat lib/pkgconfig/sdl2.pc 
[...]
Conflicts:
Libs: -L${libdir} -Wl,-rpath,${libdir} -Wl,--enable-new-dtags -lSDL2
Libs.private: -lSDL2  -Wl,--no-undefined -lm -ldl -lpthread -lrt
Cflags: -I${includedir}/SDL2   -D_REENTRANT
```