### PR TITLE
Allow Jenkins to keep $WORKSPACE

### DIFF
--- a/3ds/1_download_library.sh
+++ b/3ds/1_download_library.sh
@@ -3,10 +3,11 @@
 # abort on errors
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
+
+# Installation directory
+set_workspace
 
 msg " [1] Checking devkitARM"
 

--- a/3ds/2_build_toolchain.sh
+++ b/3ds/2_build_toolchain.sh
@@ -3,10 +3,11 @@
 # abort on error
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
+
+# Installation directory
+set_workspace
 
 # Number of CPU
 nproc=$(nproc)

--- a/android/1_download_library.sh
+++ b/android/1_download_library.sh
@@ -3,10 +3,11 @@
 # abort on errors
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
+
+# Installation directory
+set_workspace
 
 # Supported os : "darwin" or "linux"
 os=`uname`
@@ -18,8 +19,6 @@ if [ $os = "Darwin" ] ; then
 	echo "#"
 	echo "#############################################################"
 fi
-
-export WORKSPACE=$PWD
 
 # Prepare toolchain
 

--- a/android/2_build_toolchain.sh
+++ b/android/2_build_toolchain.sh
@@ -3,10 +3,11 @@
 # abort on error
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
+
+# Installation directory
+set_workspace
 
 # Number of CPU
 nproc=$(nproc)

--- a/android/4_build_liblcf.sh
+++ b/android/4_build_liblcf.sh
@@ -3,10 +3,11 @@
 # abort on errors
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
+
+# Installation directory
+set_workspace
 
 # Cloning or pulling the liblcf repository
 if [ -d liblcf/.git ]; then

--- a/emscripten/1_download_library.sh
+++ b/emscripten/1_download_library.sh
@@ -3,12 +3,13 @@
 # abort on errors
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
 # Override ICU version to 60.2
 source $SCRIPT_DIR/packages.sh
+
+# Installation directory
+set_workspace
 
 msg " [1] Preparing Emscripten SDK"
 

--- a/emscripten/2_build_toolchain.sh
+++ b/emscripten/2_build_toolchain.sh
@@ -3,12 +3,13 @@
 # abort on error
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
 # Override ICU version to 60.2
 source $SCRIPT_DIR/packages.sh
+
+# Installation directory
+set_workspace
 
 # Number of CPU
 nproc=$(nproc)

--- a/ios/1_download_library.sh
+++ b/ios/1_download_library.sh
@@ -3,10 +3,11 @@
 # abort on errors
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
+
+# Installation directory
+set_workspace
 
 msg " [1] Preparing libraries"
 

--- a/ios/2_build_toolchain.sh
+++ b/ios/2_build_toolchain.sh
@@ -8,10 +8,11 @@ fi
 # abort on error
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
+
+# Installation directory
+set_workspace
 
 # Number of CPU
 nproc=$(getconf _NPROCESSORS_ONLN)

--- a/linux-static/1_download_library.sh
+++ b/linux-static/1_download_library.sh
@@ -3,10 +3,11 @@
 # abort on errors
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
+
+# Installation directory
+set_workspace
 
 msg " [1] Preparing libraries"
 

--- a/linux-static/2_build_toolchain.sh
+++ b/linux-static/2_build_toolchain.sh
@@ -3,10 +3,11 @@
 # abort on error
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
+
+# Installation directory
+set_workspace
 
 # Number of CPU
 nproc=$(nproc)

--- a/osx/1_download_library.sh
+++ b/osx/1_download_library.sh
@@ -3,10 +3,11 @@
 # abort on errors
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
+
+# Installation directory
+set_workspace
 
 msg " [1] Downloading generic libraries"
 

--- a/osx/2_build_toolchain.sh
+++ b/osx/2_build_toolchain.sh
@@ -8,10 +8,11 @@ fi
 # abort on error
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
+
+# Installation directory
+set_workspace
 
 # Number of CPU
 nproc=$(getconf _NPROCESSORS_ONLN)

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -56,6 +56,13 @@ function test_ccache {
 	fi
 }
 
+# for installation outside of Jenkins
+function set_workspace {
+	if [[ -z $WORKSPACE ]]; then
+		export WORKSPACE=$PWD
+	fi
+}
+
 # generic autotools library installer
 function install_lib {
 	msg "**** Building ${1%-*} ****"

--- a/switch/1_download_library.sh
+++ b/switch/1_download_library.sh
@@ -3,10 +3,11 @@
 # abort on errors
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
+
+# Installation directory
+set_workspace
 
 msg " [1] Checking devkitA64"
 

--- a/switch/2_build_toolchain.sh
+++ b/switch/2_build_toolchain.sh
@@ -3,10 +3,11 @@
 # abort on error
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
+
+# Installation directory
+set_workspace
 
 # Number of CPU
 nproc=$(nproc)

--- a/vita/1_download_library.sh
+++ b/vita/1_download_library.sh
@@ -3,10 +3,11 @@
 # abort on errors
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
+
+# Installation directory
+set_workspace
 
 function download_and_extract_shaders {
 	mkdir vitashaders

--- a/vita/2_build_toolchain.sh
+++ b/vita/2_build_toolchain.sh
@@ -3,10 +3,11 @@
 # abort on errors
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
+
+# Installation directory
+set_workspace
 
 # Number of CPU
 nproc=$(nproc)

--- a/wii/1_download_library.sh
+++ b/wii/1_download_library.sh
@@ -3,13 +3,13 @@
 # abort on errors
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
-
 # Override ICU version to 58.1, custom SDL
 source $SCRIPT_DIR/packages.sh
+
+# Installation directory
+set_workspace
 
 msg " [1] Checking devkitPPC"
 

--- a/wii/2_build_toolchain.sh
+++ b/wii/2_build_toolchain.sh
@@ -3,13 +3,13 @@
 # abort on error
 set -e
 
-export WORKSPACE=$PWD
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/../shared/import.sh
-
 # Override ICU version to 58.1, custom SDL
 source $SCRIPT_DIR/packages.sh
+
+# Installation directory
+set_workspace
 
 # Number of CPU
 nproc=$(nproc)


### PR DESCRIPTION
This changes installation paths only when building locally.

Reason: On jenkins, every job only targets one toolchain, so further separating is not necessary. This allows us to simplify paths for all jobs, removing the last component:

```sh
export STATICLIBSPATH="$JENKINS_HOME/workspace/toolchain-linux-static/[linux-static]"
export TOOLCHAIN_DIR=${WORKSPACE}/../toolchain-switch/[switch]
export TOOLCHAIN_DIR=${WORKSPACE}/../toolchain-3ds/[3ds]
export TOOLCHAIN_DIR=${WORKSPACE}/../toolchain-wii/[wii]
export TOOLCHAIN_DIR=${WORKSPACE}/../toolchain-vita/[vita]
```