### PR TITLE
Linux: Enable fpic

### DIFF
--- a/linux-static/2_build_toolchain.sh
+++ b/linux-static/2_build_toolchain.sh
@@ -28,9 +28,10 @@ echo "Preparing toolchain"
 
 export PLATFORM_PREFIX=$WORKSPACE
 
-export CFLAGS="-Os -g0 -ffunction-sections -fdata-sections"
+export CFLAGS="-Os -g0 -fPIC -ffunction-sections -fdata-sections"
 export CXXFLAGS=$CFLAGS
 export CPPFLAGS="-I$PLATFORM_PREFIX/include"
+export LDFLAGS="-fPIC -L$PLATFORM_PREFIX/lib"
 export MAKEFLAGS="-j${nproc:-2}"
 export PKG_CONFIG_PATH=$WORKSPACE/lib/pkgconfig
 export PKG_CONFIG_LIBDIR=$PKG_CONFIG_PATH

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -235,6 +235,7 @@ function patches_common {
 		# compile fix
 		(cd $LIBXMP_LITE_DIR
 			patch -Np1 < $_SCRIPT_DIR/libxmp-a0288352.patch
+			patch -Np1 < $_SCRIPT_DIR/libxmp-no-symver.patch
 
 			# Use custom CMakeLists.txt
 			cp $_SCRIPT_DIR/CMakeLists_xmplite.txt ./CMakeLists.txt

--- a/shared/libxmp-no-symver.patch
+++ b/shared/libxmp-no-symver.patch
@@ -1,0 +1,12 @@
+diff -Naur libxmp-lite-4.4.1-orig/src/common.h libxmp-lite-4.4.1/src/common.h
+--- libxmp-lite-4.4.1-orig/src/common.h	2020-07-13 20:08:30.532749896 +0200
++++ libxmp-lite-4.4.1/src/common.h	2020-07-13 20:08:41.922845946 +0200
+@@ -11,7 +11,7 @@
+ 
+ #if defined(__GNUC__) || defined(__clang__)
+ #if !defined(WIN32) && !defined(__ANDROID__) && !defined(__APPLE__) && !defined(__AMIGA__) && !defined(B_BEOS_VERSION) && !defined(__ATHEOS__) && !defined(EMSCRIPTEN) && !defined(__MINT__) 
+-#define USE_VERSIONED_SYMBOLS
++//#define USE_VERSIONED_SYMBOLS
+ #endif
+ #endif
+ 


### PR DESCRIPTION
macOS enforces position independent code (tested this) and on Android the NDK seems to enforce fPIC already. At least we have no relocation errors on Android (we have multiple .so files there).