### PR TITLE
Add nlohmann-json for Linux, macOS, Windows and emscripten

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,20 +3,27 @@ library.
 
 In short:
 expat: MIT
+FluidLite: LGPLv2.1+
+fmt: MIT
 freetype: FreeType License or GPLv2 or later (see docs/LICENSE.TXT)
 harfbuzz: MIT
 icu4c: ICU license
-libmodplug: Public Domain
-libmpg123: LGPLv2.1
-libogg: BSD
-libpng: zlib
-libsndfile: LGPLv2.1
-libvorbis: BSD
-libwildmidi: LGPLv3
-libxmp-lite: MIT
+modplug: Public Domain
+mpg123: LGPLv2.1+
+nlohmann-json: MIT
+ogg: BSD
+opus: BSD    
+opusfile: BSD   
 pixman: MIT
-SDL2: zlib
+png: zlib
+samplerate: BSD
 SDL2 image: zlib
 SDL2 mixer: zlib
+SDL2: zlib
+sndfile: LGPLv2.1+
 speexdsp: BSD
+vorbis: BSD
+wildmidi: LGPLv3+
+xmp-lite: MIT
 zlib: zlib
+

--- a/emscripten/1_download_library.sh
+++ b/emscripten/1_download_library.sh
@@ -109,6 +109,10 @@ download_and_extract $OPUSFILE_URL
 rm -rf $FLUIDLITE_DIR
 download_and_extract $FLUIDLITE_URL
 
+# nlohmann-json
+rm -rf $NLOHMANNJSON_DIR
+download_and_extract $NLOHMANNJSON_URL
+
 # fmt
 rm -rf $FMT_DIR
 download_and_extract $FMT_URL

--- a/emscripten/2_build_toolchain.sh
+++ b/emscripten/2_build_toolchain.sh
@@ -105,6 +105,7 @@ install_lib $SPEEXDSP_DIR $SPEEXDSP_ARGS
 install_lib $OPUS_DIR $OPUS_ARGS
 install_lib $OPUSFILE_DIR $OPUSFILE_ARGS
 install_lib_cmake $FLUIDLITE_DIR $FLUIDLITE_ARGS -DENABLE_SF3=ON
+install_lib_cmake $NLOHMANNJSON_DIR $NLOHMANNJSON_ARGS
 install_lib_cmake $FMT_DIR $FMT_ARGS
 
 install_lib_sdl2

--- a/linux-static/1_download_library.sh
+++ b/linux-static/1_download_library.sh
@@ -74,6 +74,10 @@ download_and_extract $OPUSFILE_URL
 rm -rf $FLUIDLITE_DIR
 download_and_extract $FLUIDLITE_URL
 
+# nlohmann-json
+rm -rf $NLOHMANNJSON_DIR
+download_and_extract $NLOHMANNJSON_URL
+
 # fmt
 rm -rf $FMT_DIR
 download_and_extract $FMT_URL

--- a/linux-static/2_build_toolchain.sh
+++ b/linux-static/2_build_toolchain.sh
@@ -57,6 +57,7 @@ install_lib_cmake $WILDMIDI_DIR $WILDMIDI_ARGS
 install_lib $OPUS_DIR $OPUS_ARGS
 install_lib $OPUSFILE_DIR $OPUSFILE_ARGS
 install_lib_cmake $FLUIDLITE_DIR $FLUIDLITE_ARGS -DENABLE_SF3=ON
+install_lib_cmake $NLOHMANNJSON_DIR $NLOHMANNJSON_ARGS
 install_lib_cmake $FMT_DIR $FMT_ARGS
 install_lib $ICU_DIR/source $ICU_ARGS
 install_lib $SDL2_DIR $SDL2_ARGS PULSEAUDIO_CFLAGS=-Ixxxdir PULSEAUDIO_LIBS=-lxxxlib

--- a/osx/1_download_library.sh
+++ b/osx/1_download_library.sh
@@ -74,6 +74,10 @@ download_and_extract $OPUSFILE_URL
 rm -rf $FLUIDLITE_DIR
 download_and_extract $FLUIDLITE_URL
 
+# nlohmann-json
+rm -rf $NLOHMANNJSON_DIR
+download_and_extract $NLOHMANNJSON_URL
+
 # fmt
 rm -rf $FMT_DIR
 download_and_extract $FMT_URL

--- a/osx/2_build_toolchain.sh
+++ b/osx/2_build_toolchain.sh
@@ -83,6 +83,7 @@ install_lib_cmake $WILDMIDI_DIR $WILDMIDI_ARGS
 install_lib $OPUS_DIR $OPUS_ARGS
 install_lib $OPUSFILE_DIR $OPUSFILE_ARGS
 install_lib_cmake $FLUIDLITE_DIR $FLUIDLITE_ARGS -DENABLE_SF3=ON
+install_lib_cmake $NLOHMANNJSON_DIR $NLOHMANNJSON_ARGS
 install_lib_cmake $FMT_DIR $FMT_ARGS
 install_lib $ICU_DIR/source $ICU_ARGS
 install_lib $SDL2_DIR $SDL2_ARGS

--- a/shared/add_lib.sh
+++ b/shared/add_lib.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+echo "REMOVE THIS LINE";exit 1
+
+# Edit these variables
+# Remove _cmake when the lib uses autotools for building
+NAME=nlohmann-json
+LIBVAR=NLOHMANNJSON
+TOOLCHAIN_DIRS=(linux-static osx android emscripten 3ds switch vita wii ios)
+CMAKE=_cmake
+
+#-------
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+repA="# $NAME\nrm -rf \$${LIBVAR}_DIR\ndownload_and_extract \$${LIBVAR}_URL\n"
+
+repB="install_lib${CMAKE} \$${LIBVAR}_DIR \$${LIBVAR}_ARGS"
+
+for n in "${TOOLCHAIN_DIRS[@]}"
+do
+	echo "Updating $n"
+	sed -i "/# fmt/i\\$repA" $SCRIPT_DIR/../$n/1_*.sh
+
+	if [ $n == "android" ]; then
+		OFFSET="\t"
+	else
+		OFFSET=""
+	fi
+
+	sed -i "/install_lib_cmake \$FMT_DIR/i\\${OFFSET}$repB" $SCRIPT_DIR/../$n/2_*.sh
+
+done
+
+
+

--- a/shared/packages.sh
+++ b/shared/packages.sh
@@ -100,6 +100,12 @@ FLUIDLITE_URL="https://github.com/divideconcept/$lib/archive/$ver.zip"
 FLUIDLITE_DIR="$lib-$ver"
 FLUIDLITE_ARGS="-DFLUIDLITE_BUILD_STATIC=ON -DFLUIDLITE_BUILD_SHARED=OFF"
 
+lib=json
+ver=3.9.1
+NLOHMANNJSON_URL="https://github.com/nlohmann/$lib/archive/v$ver.tar.gz"
+NLOHMANNJSON_DIR=$lib-$ver
+NLOHMANNJSON_ARGS="-DJSON_BuildTests=OFF"
+
 lib=fmt
 ver=6.2.0
 FMT_URL="https://github.com/fmtlib/fmt/releases/download/$ver/$lib-$ver.zip"

--- a/windows/build.cmd
+++ b/windows/build.cmd
@@ -22,7 +22,7 @@ vcpkg install --triplet x86-windows-static^
  libvorbis[core] libsndfile[core] wildmidi[core] libxmp-lite[core]^
  speexdsp[core] mpg123[core] opusfile[core] fluidlite[core]^
  sdl2-image[core] sdl2-mixer[core,nativemidi]^
- icu-easyrpg[core] fmt[core]
+ icu-easyrpg[core] nlohmann-json[core] fmt[core]
 
 :: Build 64-bit libraries
 vcpkg install --triplet x64-windows-static^
@@ -30,4 +30,4 @@ vcpkg install --triplet x64-windows-static^
  libvorbis[core] libsndfile[core] wildmidi[core] libxmp-lite[core]^
  speexdsp[core] mpg123[core] opusfile[core] fluidlite[core]^
  sdl2-image[core] sdl2-mixer[core,nativemidi]^
- icu-easyrpg[core] fmt[core]
+ icu-easyrpg[core] nlohmann-json[core] fmt[core]


### PR DESCRIPTION
Fix #87

Emscripten could be useful when tools are ported to the web.

Also added a small, ugly script which injects new lines into the 1 and 2 bash scripts.