### PR TITLE
Android: Install Android SDK 29

### DIFF
--- a/android/1_download_library.sh
+++ b/android/1_download_library.sh
@@ -55,10 +55,8 @@ cd android-sdk
 echo "y" | bin/sdkmanager --verbose "build-tools;28.0.0" --sdk_root=$PWD
 # Android SDK Platform-tools
 echo "y" | bin/sdkmanager --verbose "platform-tools" --sdk_root=$PWD
-# SDK Platform Android 3.1, API 12
-echo "y" | bin/sdkmanager --verbose "platforms;android-12" --sdk_root=$PWD
-# SDK Platform Android 8.0, API 28
-echo "y" | bin/sdkmanager --verbose "platforms;android-28" --sdk_root=$PWD
+# SDK Platform Android 10, API 29
+echo "y" | bin/sdkmanager --verbose "platforms;android-29" --sdk_root=$PWD
 # Android Support Library Repository
 echo "y" | bin/sdkmanager --verbose "extras;android;m2repository" --sdk_root=$PWD
 # Google Repository


### PR DESCRIPTION
Also removed API 12. I don't think we need this anymore.