### PR TITLE
Revamp the vita toolchain

### DIFF
--- a/vita/0_build_everything.sh
+++ b/vita/0_build_everything.sh
@@ -3,3 +3,7 @@
 ./1_download_library.sh \
 	&& ./2_build_toolchain.sh \
 	&& ./3_cleanup.sh
+
+echo
+echo "To use the local vita sdk set \"VITASDK=$PWD/vitasdk\"."
+echo

--- a/vita/1_download_library.sh
+++ b/vita/1_download_library.sh
@@ -11,14 +11,14 @@ source $SCRIPT_DIR/../shared/import.sh
 function download_and_extract_shaders {
 	mkdir vitashaders
 	cd vitashaders
-	download_and_extract https://github.com/frangarcj/vita-shader-collection/releases/download/gtu-0.1-v74/vita-shader-collection.tar.gz
+	download_and_extract https://github.com/frangarcj/vita-shader-collection/releases/download/master-0.1-v86/vita-shader-collection.tar.gz
 	cd ..
 }
 
-msg " [1] Installing Vita SDK"
+msg " [1] Installing local Vita SDK"
 
 export VITASDK=$PWD/vitasdk
-export URL="https://github.com/vitasdk/autobuilds/releases/download/master-linux-v1455/vitasdk-x86_64-linux-gnu-2021-04-07_18-41-35.tar.bz2"
+export URL="https://github.com/vitasdk/autobuilds/releases/download/master-linux-v1476/vitasdk-x86_64-linux-gnu-2021-05-09_07-02-53.tar.bz2"
 
 mkdir -p vitasdk
 curl -sSLR -o vitasdk-nightly.tar.bz2 "$URL"
@@ -107,9 +107,5 @@ msg " [3] Downloading platform libraries"
 # libvitashaders
 rm -rf vitashaders
 download_and_extract_shaders
-
-git_clone https://github.com/vitasdk/vdpm
-
-git_clone https://github.com/vitasdk/vita-headers
 
 git_clone https://github.com/frangarcj/vita2dlib

--- a/vita/2_build_toolchain.sh
+++ b/vita/2_build_toolchain.sh
@@ -56,11 +56,8 @@ echo "Preparing toolchain"
 export VITASDK=$PWD/vitasdk
 export PATH=$PWD/vitasdk/bin:$PATH
 
-export PLATFORM_PREFIX=$WORKSPACE
 export TARGET_HOST=arm-vita-eabi
-export PKG_CONFIG=/usr/bin/pkg-config
-unset PKG_CONFIG_PATH
-export PKG_CONFIG_LIBDIR=$PLATFORM_PREFIX/lib/pkgconfig
+export PLATFORM_PREFIX=$VITASDK/$TARGET_HOST
 export MAKEFLAGS="-j${nproc:-2}"
 
 function set_build_flags {
@@ -72,8 +69,7 @@ function set_build_flags {
 	fi
 	export CFLAGS="-g0 -O2"
 	export CXXFLAGS=$CFLAGS
-	export CPPFLAGS="-I$PLATFORM_PREFIX/include -DPSP2"
-	export LDFLAGS="-L$PLATFORM_PREFIX/lib"
+	export CPPFLAGS="-DPSP2"
 }
 
 function install_lib_vita2d() {
@@ -92,22 +88,19 @@ function install_shaders() {
 	msg "Copying precompiled shaders"
 
 	(cd vitashaders
-		cp -a ./lib/. $VITASDK/$TARGET_HOST/lib/
-		cp -a ./includes/. $VITASDK/$TARGET_HOST/include/
+		cp -a ./lib/. $PLATFORM_PREFIX/lib/
+		cp -a ./includes/. $PLATFORM_PREFIX/include/
 	)
 }
 
 function install_vdpm() {
-	msg "Installing VDPM"
-	(cd vdpm
-		./install-all.sh
-	)
+	msg "Installing VDPM packages"
+	vdpm libjpeg-turbo # for vita2d
 }
 
 install_lib_icu_native
 
 install_vdpm
-install_lib_vita2d
 
 set_build_flags
 install_lib_zlib
@@ -130,4 +123,5 @@ install_lib $OPUSFILE_DIR $OPUSFILE_ARGS
 install_lib_cmake $FMT_DIR $FMT_ARGS
 install_lib_icu_cross
 
+install_lib_vita2d
 install_shaders

--- a/vita/3_cleanup.sh
+++ b/vita/3_cleanup.sh
@@ -8,6 +8,6 @@ source $SCRIPT_DIR/../shared/import.sh
 
 cleanup
 
-rm -rf vdpm/ vita2dlib/ vitashaders/ vita-headers/
+rm -rf vita2dlib/ vitashaders/
 
 echo " -> done"

--- a/vita/README.md
+++ b/vita/README.md
@@ -5,3 +5,7 @@
 Local build process:
 
 Run `0_build_everything.sh` in a terminal
+
+Note: Since we overwrite some libraries from vitasdk with newer versions,
+we use our own local installation. This means you need to redefine `$VITASDK`
+when targetting our builds.


### PR DESCRIPTION
Allows us to build liblcf and Player(soon) with cmake.

liblcf:
```console
export VITASDK=../buildscripts/vita/vitasdk
cmake -B build-vita . -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DLIBLCF_WITH_XML=OFF -DLIBLCF_ENABLE_TOOLS=OFF
cmake --build build-vita
```