### PR TITLE
Bump vitasdk and use upstream libvita2d

### DIFF
--- a/vita/1_download_library.sh
+++ b/vita/1_download_library.sh
@@ -18,7 +18,7 @@ function download_and_extract_shaders {
 msg " [1] Installing local Vita SDK"
 
 export VITASDK=$PWD/vitasdk
-export URL="https://github.com/vitasdk/autobuilds/releases/download/master-linux-v1498/vitasdk-x86_64-linux-gnu-2021-06-13_20-39-05.tar.bz2"
+export URL="https://github.com/vitasdk/autobuilds/releases/download/master-linux-v2.341/vitasdk-x86_64-linux-gnu-2022-05-20_11-10-55.tar.bz2"
 
 mkdir -p vitasdk
 curl -sSLR -o vitasdk-nightly.tar.bz2 "$URL"
@@ -104,11 +104,8 @@ download_and_extract $ICUDATA_URL
 
 msg " [3] Downloading platform libraries"
 
-# libvitashaders
-rm -rf vitashaders
-download_and_extract_shaders
-
-git_clone https://github.com/frangarcj/vita2dlib
+# libvita2d
+git_clone https://github.com/xerpi/libvita2d.git
 
 # liblcf
 rm -rf liblcf

--- a/vita/2_build_toolchain.sh
+++ b/vita/2_build_toolchain.sh
@@ -41,7 +41,7 @@ if [ ! -f .patches-applied ]; then
 	patch -Np0 < $SCRIPT_DIR/icu69-vita.patch
 
 	# Disable vita2dlib jpeg dependency
-	patch -Np0 < $SCRIPT_DIR/vita2dlib-no-jpeg.patch
+	patch -Np0 < $SCRIPT_DIR/libvita2d-no-jpeg.patch
 
 	# Allow the cmake toolchain finding libfmt
 	patch -Np0 < $SCRIPT_DIR/vitasdk-cmake.patch
@@ -76,21 +76,10 @@ function set_build_flags {
 function install_lib_vita2d() {
 	msg "Building patched libvita2d"
 
-	cd vita2dlib
-	git checkout fbo
-	cd libvita2d
-	make clean
-	make -j1
-	make install
-	cd ../..
-}
-
-function install_shaders() {
-	msg "Copying precompiled shaders"
-
-	(cd vitashaders
-		cp -a ./lib/. $PLATFORM_PREFIX/lib/
-		cp -a ./includes/. $PLATFORM_PREFIX/include/
+	(cd libvita2d/libvita2d
+		make clean
+		make -j1 CFLAGS='-Wl,-q -Wall -O3 -I$(INCLUDES) -I$(VITASDK)/arm-vita-eabi/include/freetype2'
+		make install
 	)
 }
 
@@ -119,4 +108,3 @@ install_lib_icu_cross
 install_lib_liblcf
 
 install_lib_vita2d
-install_shaders

--- a/vita/3_cleanup.sh
+++ b/vita/3_cleanup.sh
@@ -8,6 +8,6 @@ source $SCRIPT_DIR/../shared/import.sh
 
 cleanup
 
-rm -rf vita2dlib/ vitashaders/
+rm -rf libvita2d/
 
 echo " -> done"

--- a/vita/libvita2d-no-jpeg.patch
+++ b/vita/libvita2d-no-jpeg.patch
@@ -1,7 +1,6 @@
-diff '--color=auto' -Naur vita2dlib-orig/libvita2d/source/vita2d_image_jpeg.c vita2dlib/libvita2d/source/vita2d_image_jpeg.c
---- vita2dlib-orig/libvita2d/source/vita2d_image_jpeg.c	2021-07-12 15:32:51.677340577 +0200
-+++ vita2dlib/libvita2d/source/vita2d_image_jpeg.c	2021-07-12 15:34:30.317341896 +0200
-@@ -3,11 +3,12 @@
+--- libvita2d-orig/libvita2d/source/vita2d_image_jpeg.c	2022-05-22 15:48:57.167589790 +0200
++++ libvita2d/libvita2d/source/vita2d_image_jpeg.c	2022-05-22 15:49:53.487590494 +0200
+@@ -3,7 +3,7 @@
  #include <string.h>
  #include <psp2/io/fcntl.h>
  #include <psp2/gxm.h>
@@ -9,13 +8,16 @@ diff '--color=auto' -Naur vita2dlib-orig/libvita2d/source/vita2d_image_jpeg.c vi
 +//#include <jpeglib.h>
  #include "vita2d.h"
  
+ // Following official documentation max width or height of the texture is 4096
+@@ -11,6 +11,7 @@
+ 
  static vita2d_texture *_vita2d_load_JPEG_generic(struct jpeg_decompress_struct *jinfo, struct jpeg_error_mgr *jerr)
  {
 +#if 0
- 	float downScaleWidth = (float)jinfo->image_width / 4096;
- 	float downScaleHeight = (float)jinfo->image_height / 4096;
- 	float downScale = (downScaleWidth >= downScaleHeight) ? downScaleWidth : downScaleHeight;
-@@ -48,11 +49,14 @@
+ 	unsigned int longer = jinfo->image_width > jinfo->image_height ? jinfo->image_width : jinfo->image_height;
+ 	float downScale = (float)longer / (float)MAX_TEXTURE;
+ 	jinfo->scale_denom = ceil(downScale);
+@@ -47,11 +48,14 @@
  	jpeg_finish_decompress(jinfo);
  
  	return texture;
@@ -28,9 +30,9 @@ diff '--color=auto' -Naur vita2dlib-orig/libvita2d/source/vita2d_image_jpeg.c vi
  {
 +#if 0
  	FILE *fp;
- 	if ((fp = fopen(filename, "rb")) < 0) {
+ 	if ((fp = fopen(filename, "rb")) <= 0) {
  		return NULL;
-@@ -81,11 +85,14 @@
+@@ -80,11 +84,14 @@
  
  	fclose(fp);
  	return texture;
@@ -45,7 +47,7 @@ diff '--color=auto' -Naur vita2dlib-orig/libvita2d/source/vita2d_image_jpeg.c vi
  	unsigned int magic = *(unsigned int *)buffer;
  	if (magic != 0xE0FFD8FF && magic != 0xE1FFD8FF) {
  		return NULL;
-@@ -105,4 +112,6 @@
+@@ -104,4 +111,6 @@
  	jpeg_destroy_decompress(&jinfo);
  
  	return texture;


### PR DESCRIPTION
The new make line for libvita2d fixes a crash

The fbo stuff is only used for shaders.
I'm removing all the shader code. Nobody wants to maintain this.