### PR TITLE
Freetype (vcpkg): Link to external zlib to fix linking errors

### DIFF
--- a/windows/build.cmd
+++ b/windows/build.cmd
@@ -10,14 +10,14 @@ vcpkg install --triplet x86-windows^
 :: Using [core] everywhere to prevent surprises when new default-features are
 :: added to libraries.
 vcpkg install --triplet x86-windows-static --recurse^
- libpng[core] expat[core] pixman[core] freetype[core] harfbuzz[core]^
+ libpng[core] expat[core] pixman[core] freetype[core,zlib] harfbuzz[core]^
  libvorbis[core] libsndfile[core] wildmidi[core] libxmp-lite[core]^
  speexdsp[core] mpg123[core] opusfile[core] fluidsynth-easyrpg[core]^
  sdl2-image[core] icu-easyrpg[core] nlohmann-json[core] fmt[core]
 
 :: Build 64-bit libraries
 vcpkg install --triplet x64-windows-static --recurse^
- libpng[core] expat[core] pixman[core] freetype[core] harfbuzz[core]^
+ libpng[core] expat[core] pixman[core] freetype[core,zlib] harfbuzz[core]^
  libvorbis[core] libsndfile[core] wildmidi[core] libxmp-lite[core]^
  speexdsp[core] mpg123[core] opusfile[core] fluidsynth-easyrpg[core]^
  sdl2-image[core] icu-easyrpg[core] nlohmann-json[core] fmt[core]


### PR DESCRIPTION
That's the fix I manually applied on the buildbot so it should work.