### PR TITLE
Fix libsndfile static linking

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -263,6 +263,8 @@ function patches_common {
 	# disable libsndfile examples and tests
 	if [ -d "$LIBSNDFILE_DIR" ]; then
 		(cd $LIBSNDFILE_DIR
+			# Remove next line when next version is out
+			patch -Np1 < $_SCRIPT_DIR/libsndfile-subst-external-libs.patch
 			perl -pi -e 's/ examples tests//' Makefile.am
 			perl -pi -e 's/ examples regtest tests programs//' Makefile.am
 			autoreconf -fi

--- a/shared/libsndfile-subst-external-libs.patch
+++ b/shared/libsndfile-subst-external-libs.patch
@@ -1,0 +1,21 @@
+From d25096a098f4f3446400a129909d172b6b702962 Mon Sep 17 00:00:00 2001
+From: Michael Cho <cho-m@tuta.io>
+Date: Sun, 17 Apr 2022 21:31:07 -0700
+Subject: [PATCH] configure.ac: substitute EXTERNAL_MPEG_LIBS in sndfile.pc
+
+---
+ configure.ac | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configure.ac b/configure.ac
+index 727b67bc0..a4c776d70 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -739,6 +739,7 @@ AC_SUBST(SNDIO_LIBS)
+ AC_SUBST(EXTERNAL_XIPH_CFLAGS)
+ AC_SUBST(EXTERNAL_XIPH_LIBS)
+ AC_SUBST(EXTERNAL_XIPH_REQUIRE)
++AC_SUBST(EXTERNAL_MPEG_LIBS)
+ AC_SUBST(EXTERNAL_MPEG_REQUIRE)
+ AC_SUBST(MPG123_CFLAGS)
+ AC_SUBST(MPG123_LIBS)

--- a/shared/packages.sh
+++ b/shared/packages.sh
@@ -6,7 +6,7 @@ ZLIB_URL="https://zlib.net/$lib-$ver.tar.gz"
 ZLIB_DIR="$lib-$ver"
 
 lib=libpng
-ver=1.6.37
+ver=1.6.38
 LIBPNG_URL="https://download.sourceforge.net/libpng/$lib-$ver.tar.xz"
 LIBPNG_DIR="$lib-$ver"
 


### PR DESCRIPTION
Bump libpng to 1.6.38

---------

Already applied the libsndfile fix manually to unbreak the build