### PR TITLE
Bump zlib to 1.2.13 and expat to 2.4.9

### DIFF
--- a/shared/packages.sh
+++ b/shared/packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 lib=zlib
-ver=1.2.12
+ver=1.2.13
 ZLIB_URL="https://zlib.net/$lib-$ver.tar.gz"
 ZLIB_DIR="$lib-$ver"
 
@@ -29,7 +29,7 @@ PIXMAN_DIR="$lib-$ver"
 PIXMAN_ARGS="--disable-libpng --enable-dependency-tracking"
 
 lib=expat
-ver=2.4.8
+ver=2.4.9
 EXPAT_URL="https://github.com/libexpat/libexpat/releases/download/R_${ver//./_}/$lib-$ver.tar.bz2"
 EXPAT_DIR="$lib-$ver"
 EXPAT_ARGS="-DEXPAT_BUILD_TOOLS=OFF -DEXPAT_BUILD_EXAMPLES=OFF -DEXPAT_BUILD_TESTS=OFF -DEXPAT_BUILD_DOCS=OFF -DEXPAT_SHARED_LIBS=OFF"


### PR DESCRIPTION
These releases fix a CVE

Fix #133 

Only tested on Linux but zlib and expat are usually safe :thinking: 