### PR TITLE
Fix icudata not working in macOS universal binary

### DIFF
--- a/macos/2_build_toolchain.sh
+++ b/macos/2_build_toolchain.sh
@@ -82,6 +82,7 @@ function build() {
 	install_lib_cmake $NLOHMANNJSON_DIR $NLOHMANNJSON_ARGS
 	install_lib_cmake $FMT_DIR $FMT_ARGS
 	install_lib_icu_cross
+	icu_force_data_install
 	install_lib_liblcf
 	install_lib $SDL2_DIR $SDL2_ARGS --disable-assembly
 }

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -226,7 +226,7 @@ function icu_force_data_install {
 		make clean
 		make
 
-		cp ../lib/libicudata.a "$WORKSPACE/lib/"
+		cp ../lib/libicudata.a "$PLATFORM_PREFIX/lib/"
 	)
 }
 


### PR DESCRIPTION
We know this problem from other systems making fixing this easy

Thanks to brianum (admin of https://vampiresdawn.org fanpage) for reporting.

-----

Already replaced the 0.8 release with a working version.