### PR TITLE
Fix opusfile compilation in c89 mode

### DIFF
--- a/3ds/2_build_toolchain.sh
+++ b/3ds/2_build_toolchain.sh
@@ -34,6 +34,11 @@ if [ ! -f .patches-applied ]; then
 		autoreconf -fi
 	)
 
+	# Fix opusfile
+	(cd $OPUSFILE_DIR
+		patch -Np1 < $SCRIPT_DIR/../shared/extra/opusfile-devkit.patch
+	)
+
 	# Fix icu build
 	perl -pi -e 's/xlocale/locale/' icu/source/i18n/digitlst.cpp
 	cp -rup icu icu-native

--- a/shared/extra/opusfile-devkit.patch
+++ b/shared/extra/opusfile-devkit.patch
@@ -1,0 +1,15 @@
+diff --color -Naur opusfile-0.12.original/src/internal.h opusfile-0.12/src/internal.h
+--- opusfile-0.12.original/src/internal.h	2020-06-27 02:44:15.000000000 +0200
++++ opusfile-0.12/src/internal.h	2023-07-01 01:04:05.753151020 +0200
+@@ -28,6 +28,11 @@
+ #  define _FILE_OFFSET_BITS 64
+ # endif
+ 
++#ifdef __GNUC__
++/* c89 fix for devkitXXX */
++# define inline __inline__
++#endif
++
+ # include <stdlib.h>
+ # include <opusfile.h>
+ 

--- a/switch/2_build_toolchain.sh
+++ b/switch/2_build_toolchain.sh
@@ -31,6 +31,11 @@ if [ ! -f .patches-applied ]; then
 		autoreconf -fi
 	)
 
+	# Fix opusfile
+	(cd $OPUSFILE_DIR
+		patch -Np1 < $SCRIPT_DIR/../shared/extra/opusfile-devkit.patch
+	)
+
 	# disable libsamplerate examples and tests
 	(cd $LIBSAMPLERATE_DIR
 		perl -pi -e 's/examples tests//' Makefile.am


### PR DESCRIPTION
broken here: https://github.com/devkitPro/newlib/commit/68781b6d72c7dead3d65009cb18ccdfe86bc76db

Reason is c89 does not know inline, so using a GCC extension: https://gcc.gnu.org/onlinedocs/gcc-13.1.0/gcc/Alternate-Keywords.html

---

~~Commit untested, as usual.~~ tested for 3DS toolchain.
![magic](https://media.giphy.com/media/LR5UmQvLDDRqp9BI9x/giphy.gif)