### PR TITLE
Add inih and lhasa

### DIFF
--- a/3ds/1_download_library.sh
+++ b/3ds/1_download_library.sh
@@ -80,6 +80,14 @@ download_and_extract $OPUSFILE_URL
 rm -rf $FLUIDLITE_DIR
 download_and_extract $FLUIDLITE_URL
 
+# inih
+rm -rf $INIH_DIR
+download_and_extract $INIH_URL
+
+# lhasa
+rm -rf $LHASA_DIR
+download_and_extract $LHASA_URL
+
 # fmt
 rm -rf $FMT_DIR
 download_and_extract $FMT_URL

--- a/3ds/2_build_toolchain.sh
+++ b/3ds/2_build_toolchain.sh
@@ -39,6 +39,11 @@ if [ ! -f .patches-applied ]; then
 		patch -Np1 < $SCRIPT_DIR/../shared/extra/opusfile-devkit.patch
 	)
 
+	# Fix lhasa
+	(cd $LHASA_DIR
+		patch -Np1 < $SCRIPT_DIR/../shared/extra/lhasa.patch
+	)
+
 	# Fix icu build
 	perl -pi -e 's/xlocale/locale/' icu/source/i18n/digitlst.cpp
 	cp -rup icu icu-native
@@ -95,6 +100,8 @@ install_lib_cmake $WILDMIDI_DIR $WILDMIDI_ARGS
 install_lib $OPUS_DIR $OPUS_ARGS
 install_lib $OPUSFILE_DIR $OPUSFILE_ARGS
 install_lib_cmake $FLUIDLITE_DIR $FLUIDLITE_ARGS
+install_lib_meson $INIH_DIR $INIH_ARGS
+install_lib $LHASA_DIR $LHASA_ARGS
 install_lib_cmake $FMT_DIR $FMT_ARGS
 install_lib_icu_cross
 install_lib_liblcf

--- a/LICENSE
+++ b/LICENSE
@@ -9,6 +9,8 @@ fmt: MIT
 freetype: FreeType License or GPLv2 or later (see docs/LICENSE.TXT)
 harfbuzz: MIT
 icu4c: ICU license
+inih: BSD
+lhasa: ISC
 modplug: Public Domain
 mpg123: LGPLv2.1+
 nlohmann-json: MIT

--- a/android/1_download_library.sh
+++ b/android/1_download_library.sh
@@ -138,6 +138,14 @@ download_and_extract $OPUSFILE_URL
 rm -rf $FLUIDSYNTH_DIR
 download_and_extract $FLUIDSYNTH_URL
 
+# inih
+rm -rf $INIH_DIR
+download_and_extract $INIH_URL
+
+# lhasa
+rm -rf $LHASA_DIR
+download_and_extract $LHASA_URL
+
 # fmt
 rm -rf $FMT_DIR
 download_and_extract $FMT_URL

--- a/android/2_build_toolchain.sh
+++ b/android/2_build_toolchain.sh
@@ -119,6 +119,8 @@ function build() {
 	install_lib $OPUS_DIR $OPUS_ARGS
 	install_lib $OPUSFILE_DIR $OPUSFILE_ARGS
 	install_lib_cmake $FLUIDSYNTH_DIR $FLUIDSYNTH_ARGS
+	install_lib_meson $INIH_DIR $INIH_ARGS
+	install_lib $LHASA_DIR $LHASA_ARGS
 	install_lib_cmake $FMT_DIR $FMT_ARGS
 	install_lib_icu_cross
 	install_lib_sdl "$2"

--- a/emscripten/1_download_library.sh
+++ b/emscripten/1_download_library.sh
@@ -122,6 +122,14 @@ download_and_extract $FLUIDSYNTH_URL
 rm -rf $NLOHMANNJSON_DIR
 download_and_extract $NLOHMANNJSON_URL
 
+# inih
+rm -rf $INIH_DIR
+download_and_extract $INIH_URL
+
+# lhasa
+rm -rf $LHASA_DIR
+download_and_extract $LHASA_URL
+
 # fmt
 rm -rf $FMT_DIR
 download_and_extract $FMT_URL

--- a/emscripten/2_build_toolchain.sh
+++ b/emscripten/2_build_toolchain.sh
@@ -122,7 +122,7 @@ install_lib $OPUSFILE_DIR $OPUSFILE_ARGS
 install_lib_cmake $FLUIDSYNTH_DIR $FLUIDSYNTH_ARGS
 install_lib_cmake $NLOHMANNJSON_DIR $NLOHMANNJSON_ARGS
 install_lib_meson $INIH_DIR $INIH_ARGS
-install_lib $LHASA_DIR $LHASA_ARGS
+#install_lib $LHASA_DIR $LHASA_ARGS
 install_lib_cmake $FMT_DIR $FMT_ARGS
 
 # emscripten TARGET_HOST does not work for all libraries but SDL2 requires it

--- a/emscripten/2_build_toolchain.sh
+++ b/emscripten/2_build_toolchain.sh
@@ -121,6 +121,8 @@ install_lib $OPUS_DIR $OPUS_ARGS --disable-stack-protector
 install_lib $OPUSFILE_DIR $OPUSFILE_ARGS
 install_lib_cmake $FLUIDSYNTH_DIR $FLUIDSYNTH_ARGS
 install_lib_cmake $NLOHMANNJSON_DIR $NLOHMANNJSON_ARGS
+install_lib_meson $INIH_DIR $INIH_ARGS
+install_lib $LHASA_DIR $LHASA_ARGS
 install_lib_cmake $FMT_DIR $FMT_ARGS
 
 # emscripten TARGET_HOST does not work for all libraries but SDL2 requires it

--- a/emscripten/meson-cross.txt
+++ b/emscripten/meson-cross.txt
@@ -1,0 +1,16 @@
+[binaries]
+c = 'emcc'
+cpp = 'em++'
+ar = 'emar'
+
+[built-in options]
+c_args = []
+c_link_args = ['-sEXPORT_ALL=1']
+cpp_args = []
+cpp_link_args = ['-sEXPORT_ALL=1']
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm32'
+endian = 'little'

--- a/ios/1_download_library.sh
+++ b/ios/1_download_library.sh
@@ -74,6 +74,14 @@ download_and_extract $OPUSFILE_URL
 rm -rf $FLUIDLITE_DIR
 download_and_extract $FLUIDLITE_URL
 
+# inih
+rm -rf $INIH_DIR
+download_and_extract $INIH_URL
+
+# lhasa
+rm -rf $LHASA_DIR
+download_and_extract $LHASA_URL
+
 # fmt
 rm -rf $FMT_DIR
 download_and_extract $FMT_URL

--- a/ios/2_build_toolchain.sh
+++ b/ios/2_build_toolchain.sh
@@ -98,6 +98,8 @@ install_lib_cmake $WILDMIDI_DIR $WILDMIDI_ARGS
 install_lib $OPUS_DIR $OPUS_ARGS
 install_lib $OPUSFILE_DIR $OPUSFILE_ARGS
 install_lib_cmake $FLUIDLITE_DIR $FLUIDLITE_ARGS -DENABLE_SF3=ON
+install_lib_meson $INIH_DIR $INIH_ARGS
+install_lib $LHASA_DIR $LHASA_ARGS
 install_lib_cmake $FMT_DIR $FMT_ARGS
 install_lib_icu_cross
 install_lib_liblcf

--- a/linux-static/1_download_library.sh
+++ b/linux-static/1_download_library.sh
@@ -78,6 +78,14 @@ download_and_extract $FLUIDSYNTH_URL
 rm -rf $NLOHMANNJSON_DIR
 download_and_extract $NLOHMANNJSON_URL
 
+# inih
+rm -rf $INIH_DIR
+download_and_extract $INIH_URL
+
+# lhasa
+rm -rf $LHASA_DIR
+download_and_extract $LHASA_URL
+
 # fmt
 rm -rf $FMT_DIR
 download_and_extract $FMT_URL

--- a/linux-static/2_build_toolchain.sh
+++ b/linux-static/2_build_toolchain.sh
@@ -58,6 +58,8 @@ install_lib $OPUS_DIR $OPUS_ARGS
 install_lib $OPUSFILE_DIR $OPUSFILE_ARGS
 install_lib_cmake $FLUIDSYNTH_DIR $FLUIDSYNTH_ARGS
 install_lib_cmake $NLOHMANNJSON_DIR $NLOHMANNJSON_ARGS
+install_lib_meson $INIH_DIR $INIH_ARGS
+install_lib $LHASA_DIR $LHASA_ARGS
 install_lib_cmake $FMT_DIR $FMT_ARGS
 install_lib $ICU_DIR/source $ICU_ARGS
 install_lib_liblcf

--- a/macos/1_download_library.sh
+++ b/macos/1_download_library.sh
@@ -78,6 +78,14 @@ download_and_extract $FLUIDSYNTH_URL
 rm -rf $NLOHMANNJSON_DIR
 download_and_extract $NLOHMANNJSON_URL
 
+# inih
+rm -rf $INIH_DIR
+download_and_extract $INIH_URL
+
+# lhasa
+rm -rf $LHASA_DIR
+download_and_extract $LHASA_URL
+
 # fmt
 rm -rf $FMT_DIR
 download_and_extract $FMT_URL

--- a/macos/2_build_toolchain.sh
+++ b/macos/2_build_toolchain.sh
@@ -80,6 +80,8 @@ function build() {
 	install_lib $OPUSFILE_DIR $OPUSFILE_ARGS
 	install_lib_cmake $FLUIDSYNTH_DIR $FLUIDSYNTH_ARGS
 	install_lib_cmake $NLOHMANNJSON_DIR $NLOHMANNJSON_ARGS
+	install_lib_meson $INIH_DIR $INIH_ARGS
+	install_lib $LHASA_DIR $LHASA_ARGS
 	install_lib_cmake $FMT_DIR $FMT_ARGS
 	install_lib_icu_cross
 	icu_force_data_install

--- a/macos/2_build_toolchain.sh
+++ b/macos/2_build_toolchain.sh
@@ -23,6 +23,12 @@ if [ ! -f .patches-applied ]; then
 
 	patches_common
 
+	# Fix inih
+	# Remove when r58 is out
+	(cd $INIH_DIR
+		patch -Np1 < $SCRIPT_DIR/inih-std11.patch
+	)
+
 	cp -rp icu icu-native
 
 	touch .patches-applied

--- a/macos/2_build_toolchain.sh
+++ b/macos/2_build_toolchain.sh
@@ -55,7 +55,8 @@ function set_build_flags() {
 	fi
 	export CFLAGS="-g -O2 -mmacosx-version-min=10.9 -isysroot $SDKPATH $3"
 	export CXXFLAGS=$CFLAGS
-	export CPPFLAGS="-I$PLATFORM_PREFIX/include"
+	# ICU include is required for arm64
+	export CPPFLAGS="-I$PLATFORM_PREFIX/include -I$WORKSPACE/icu/source/common"
 	export LDFLAGS="-L$PLATFORM_PREFIX/lib $ARCH -mmacosx-version-min=10.9 -isysroot $SDKPATH"
 
 	export MACOSX_DEPLOYMENT_TARGET=10.9

--- a/macos/inih-std11.patch
+++ b/macos/inih-std11.patch
@@ -1,0 +1,26 @@
+From a4aab8874708ce62db7a866bdb2dbfca83fd392a Mon Sep 17 00:00:00 2001
+From: DownerCase <119755054+DownerCase@users.noreply.github.com>
+Date: Sun, 6 Aug 2023 20:50:28 +0100
+Subject: [PATCH] Specify C++11 std in meson build
+
+Compilers differ on what the default standard is and I had to set C++11 standard as part of the [vcpkg port](https://github.com/microsoft/vcpkg/pull/33001) to get it work on MacOS.
+
+Also you forgot to bump the version number last release.
+---
+ meson.build | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index f810525..e0340ff 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1,7 +1,8 @@
+ project('inih',
+     ['c'],
+     license : 'BSD-3-Clause',
+-    version : '56',
++    version : '57',
++    default_options : ['cpp_std=c++11']
+ )
+ 
+ #### options ####

--- a/shared/add_lib.sh
+++ b/shared/add_lib.sh
@@ -5,10 +5,10 @@ echo "REMOVE THIS LINE";exit 1
 
 # Edit these variables
 # Remove _cmake when the lib uses autotools for building
-NAME=nlohmann-json
-LIBVAR=NLOHMANNJSON
-TOOLCHAIN_DIRS=(linux-static osx android emscripten 3ds switch vita wii ios)
-CMAKE=_cmake
+NAME=lhasa
+LIBVAR=LHASA
+TOOLCHAIN_DIRS=(linux-static macos android emscripten 3ds switch vita wii ios)
+CMAKE=
 
 #-------
 
@@ -23,7 +23,7 @@ do
 	echo "Updating $n"
 	sed -i "/# fmt/i\\$repA" $SCRIPT_DIR/../$n/1_*.sh
 
-	if [ $n == "android" ]; then
+	if [ $n == "android" ] || [ $n == "macos" ]; then
 		OFFSET="\t"
 	else
 		OFFSET=""
@@ -32,6 +32,3 @@ do
 	sed -i "/install_lib_cmake \$FMT_DIR/i\\${OFFSET}$repB" $SCRIPT_DIR/../$n/2_*.sh
 
 done
-
-
-

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -122,6 +122,26 @@ function install_lib_cmake {
 	)
 }
 
+# generic meson library installer
+function install_lib_meson {
+	msg "**** Building ${1%-*} ****"
+
+	if [ -f "$PLATFORM_PREFIX/meson-cross.txt" ]; then
+		MESON_CROSS="$PLATFORM_PREFIX/meson-cross.txt"
+	else
+		MESON_CROSS="/dev/null"
+	fi
+
+	(cd $1
+		shift
+
+		meson setup build --prefix $PLATFORM_PREFIX --buildtype release \
+			-Ddefault_library=static --cross-file $MESON_CROSS $@
+		meson compile -C build
+		meson install -C build
+	)
+}
+
 function install_lib_zlib {
 	msg "**** Building zlib ****"
 

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -135,6 +135,8 @@ function install_lib_meson {
 	(cd $1
 		shift
 
+		rm -rf build
+
 		meson setup build --prefix $PLATFORM_PREFIX --buildtype release \
 			-Ddefault_library=static --cross-file $MESON_CROSS $@
 		meson compile -C build

--- a/shared/extra/lhasa.patch
+++ b/shared/extra/lhasa.patch
@@ -1,0 +1,45 @@
+diff '--color=auto' -Naur lhasa-0.4.0-orig/lib/lha_arch_unix.c lhasa-0.4.0/lib/lha_arch_unix.c
+--- lhasa-0.4.0-orig/lib/lha_arch_unix.c	2023-07-27 22:29:46.420748564 +0200
++++ lhasa-0.4.0/lib/lha_arch_unix.c	2023-07-27 22:35:08.186414880 +0200
+@@ -58,12 +58,12 @@
+ 
+ int lha_arch_chown(char *filename, int unix_uid, int unix_gid)
+ {
+-	return chown(filename, unix_uid, unix_gid) == 0;
++	return 0;
+ }
+ 
+ int lha_arch_chmod(char *filename, int unix_perms)
+ {
+-	return chmod(filename, unix_perms) == 0;
++	return 0;
+ }
+ 
+ int lha_arch_utime(char *filename, unsigned int timestamp)
+@@ -101,7 +101,7 @@
+ 	}
+ 
+ 	// Set owner and group.
+-
++#if 0
+ 	if (unix_uid >= 0) {
+ 		if (fchown(fileno, unix_uid, unix_gid) != 0) {
+ 			// On most Unix systems, only root can change
+@@ -117,6 +117,7 @@
+ 			return NULL; */
+ 		}
+ 	}
++#endif
+ 
+ 	// Set file permissions.
+ 	// File permissions must be set *after* owner and group have
+@@ -165,8 +166,7 @@
+ 
+ int lha_arch_symlink(char *path, char *target)
+ {
+-	unlink(path);
+-	return symlink(target, path) == 0;
++	return 0;
+ }
+ 
+ #endif /* LHA_ARCH_UNIX */

--- a/shared/packages.sh
+++ b/shared/packages.sh
@@ -119,6 +119,16 @@ FMT_URL="https://github.com/fmtlib/fmt/releases/download/$ver/$lib-$ver.zip"
 FMT_DIR="$lib-$ver"
 FMT_ARGS="-DFMT_DOC=OFF -DFMT_TEST=OFF"
 
+lib=inih
+ver=r57
+INIH_URL="https://github.com/benhoyt/inih/archive/refs/tags/$ver.tar.gz"
+INIH_DIR="$lib-$ver"
+
+lib=lhasa
+ver=0.4.0
+LHASA_URL="https://github.com/fragglet/lhasa/releases/download/v$ver/$lib-$ver.tar.gz"
+LHASA_DIR="$lib-$ver"
+
 lib=ICU
 ver=69.1
 ICU_URL=https://github.com/unicode-org/icu/releases/download/release-${ver//./-}/icu4c-${ver//./_}-src.tgz

--- a/switch/1_download_library.sh
+++ b/switch/1_download_library.sh
@@ -78,6 +78,14 @@ download_and_extract $OPUSFILE_URL
 rm -rf $FLUIDSYNTH_DIR
 download_and_extract $FLUIDSYNTH_URL
 
+# inih
+rm -rf $INIH_DIR
+download_and_extract $INIH_URL
+
+# lhasa
+rm -rf $LHASA_DIR
+download_and_extract $LHASA_URL
+
 # fmt
 rm -rf $FMT_DIR
 download_and_extract $FMT_URL

--- a/switch/2_build_toolchain.sh
+++ b/switch/2_build_toolchain.sh
@@ -42,6 +42,11 @@ if [ ! -f .patches-applied ]; then
 		autoreconf -fi
 	)
 
+	# Fix lhasa
+	(cd $LHASA_DIR
+		patch -Np1 < $SCRIPT_DIR/../shared/extra/lhasa.patch
+	)
+
 	cp -rup icu icu-native
 
 	touch .patches-applied
@@ -95,6 +100,8 @@ install_lib_cmake $WILDMIDI_DIR $WILDMIDI_ARGS
 install_lib $OPUS_DIR $OPUS_ARGS
 install_lib $OPUSFILE_DIR $OPUSFILE_ARGS
 install_lib_cmake $FLUIDSYNTH_DIR $FLUIDSYNTH_ARGS
+install_lib_meson $INIH_DIR $INIH_ARGS
+install_lib $LHASA_DIR $LHASA_ARGS
 install_lib_cmake $FMT_DIR $FMT_ARGS
 install_lib_icu_cross
 install_lib_liblcf

--- a/vita/1_download_library.sh
+++ b/vita/1_download_library.sh
@@ -80,6 +80,14 @@ download_and_extract $OPUSFILE_URL
 rm -rf $FLUIDLITE_DIR
 download_and_extract $FLUIDLITE_URL
 
+# inih
+rm -rf $INIH_DIR
+download_and_extract $INIH_URL
+
+# lhasa
+rm -rf $LHASA_DIR
+download_and_extract $LHASA_URL
+
 # fmt
 rm -rf $FMT_DIR
 download_and_extract $FMT_URL

--- a/vita/2_build_toolchain.sh
+++ b/vita/2_build_toolchain.sh
@@ -25,6 +25,11 @@ if [ ! -f .patches-applied ]; then
 		autoreconf -fi
 	)
 
+	# Fix lhasa
+	(cd $LHASA_DIR
+		patch -Np1 < $SCRIPT_DIR/../shared/extra/lhasa.patch
+	)
+
 	# Fix icu build
 	cp -rup icu icu-native
 	patch -Np0 < $SCRIPT_DIR/icu69-vita.patch
@@ -91,6 +96,8 @@ install_lib_cmake $WILDMIDI_DIR $WILDMIDI_ARGS
 install_lib_cmake $FLUIDLITE_DIR $FLUIDLITE_ARGS -DENABLE_SF3=ON
 install_lib $OPUS_DIR $OPUS_ARGS
 install_lib $OPUSFILE_DIR $OPUSFILE_ARGS
+install_lib_meson $INIH_DIR $INIH_ARGS
+install_lib $LHASA_DIR $LHASA_ARGS
 install_lib_cmake $FMT_DIR $FMT_ARGS
 install_lib_icu_cross
 install_lib_liblcf

--- a/wii/1_download_library.sh
+++ b/wii/1_download_library.sh
@@ -80,6 +80,14 @@ download_and_extract $OPUSFILE_URL
 rm -rf $FLUIDLITE_DIR
 download_and_extract $FLUIDLITE_URL
 
+# inih
+rm -rf $INIH_DIR
+download_and_extract $INIH_URL
+
+# lhasa
+rm -rf $LHASA_DIR
+download_and_extract $LHASA_URL
+
 # fmt
 rm -rf $FMT_DIR
 download_and_extract $FMT_URL

--- a/wii/2_build_toolchain.sh
+++ b/wii/2_build_toolchain.sh
@@ -41,6 +41,11 @@ if [ ! -f .patches-applied ]; then
 		autoreconf -fi
 	)
 
+	# Fix lhasa
+	(cd $LHASA_DIR
+		patch -Np1 < $SCRIPT_DIR/../shared/extra/lhasa.patch
+	)
+
 	# Fix icu build
 	perl -pi -e 's/xlocale/locale/' icu/source/i18n/digitlst.cpp
 	cp -rup icu icu-native
@@ -98,6 +103,8 @@ install_lib_cmake $WILDMIDI_DIR $WILDMIDI_ARGS
 install_lib_cmake $FLUIDLITE_DIR $FLUIDLITE_ARGS
 install_lib $OPUS_DIR $OPUS_ARGS
 install_lib $OPUSFILE_DIR $OPUSFILE_ARGS
+install_lib_meson $INIH_DIR $INIH_ARGS
+install_lib $LHASA_DIR $LHASA_ARGS
 install_lib_cmake $FMT_DIR $FMT_ARGS
 install_lib_icu_cross
 install_lib_liblcf

--- a/windows/build.cmd
+++ b/windows/build.cmd
@@ -9,6 +9,7 @@ vcpkg install --triplet x86-windows-static --recurse^
  libpng[core] expat[core] pixman[core] freetype[core,zlib] harfbuzz[core]^
  libvorbis[core] libsndfile[core] wildmidi[core] libxmp[core]^
  speexdsp[core] mpg123[core] opusfile[core] fluidsynth-easyrpg[core]^
+ inih[cpp] lhasa[core]^
  sdl2-image[core] icu-easyrpg[core] nlohmann-json[core] fmt[core]
 
 :: Build 64-bit libraries
@@ -16,4 +17,5 @@ vcpkg install --triplet x64-windows-static --recurse^
  libpng[core] expat[core] pixman[core] freetype[core,zlib] harfbuzz[core]^
  libvorbis[core] libsndfile[core] wildmidi[core] libxmp[core]^
  speexdsp[core] mpg123[core] opusfile[core] fluidsynth-easyrpg[core]^
+ inih[cpp] lhasa[core]^
  sdl2-image[core] icu-easyrpg[core] nlohmann-json[core] fmt[core]


### PR DESCRIPTION
inih is to get rid of vendoring in liblcf (alternative is using a different ini library).

lhasa is for https://github.com/EasyRPG/Player/pull/3033
Already tested the library on Linux and Windows.

vcpkg package submitted: https://github.com/microsoft/vcpkg/pull/32793

-----

had to add meson here. The "/dev/null" hack appears to work except for emscripten.

not tested on macOS yet