### PR TITLE
Update zlib version and use more future proof URL

### DIFF
--- a/shared/packages.sh
+++ b/shared/packages.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 lib=zlib
-ver=1.2.13
-ZLIB_URL="https://zlib.net/$lib-$ver.tar.gz"
+ver=1.3
+ZLIB_URL="https://zlib.net/fossils/$lib-$ver.tar.gz"
 ZLIB_DIR="$lib-$ver"
 
 lib=libpng


### PR DESCRIPTION
This saves us the forced update once the version changes.

Alternatively they provide a github mirror nowadays:
https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.gz

Build checks done with 3DS, Switch, Wii toolchain.