### PR TITLE
Feature: automatic library updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# update used actions
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/update_libraries.yml
+++ b/.github/workflows/update_libraries.yml
@@ -1,0 +1,52 @@
+name: Update libraries
+
+on:
+  workflow_dispatch: # allow running on-demand
+  schedule:
+    # every friday at 18:00 UTC
+    - cron: '0 18 * * 5'
+
+jobs:
+  update:
+    name: Update & Open Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade requests packaging
+
+      - name: Update library versions
+        run: |
+          python shared/updater.py
+          python shared/ini2sh.py
+
+      - name: Adapt PR body
+        run: |
+          echo "See also: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> pr-body.txt
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          add-paths: shared/packages.*
+          commit-message: Update libraries
+          branch: update/libraries
+          delete-branch: true
+          title: 'Automatic library update'
+          body-path: pr-body.txt
+          labels: |
+            update
+            automated pr
+          reviewers: carstene1ns, Ghabry, fdelapena
+
+      - name: Check outputs
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          echo "Pull Request was ${{ steps.cpr.outputs.pull-request-operation }}:"
+          echo "Number = ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "URL: ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 # Except everything in shared
 !/shared/*
 
+# Except workflows
+!/.github/*
+
 .patches-applied
 *.dat
 *.gz

--- a/shared/ini2sh.py
+++ b/shared/ini2sh.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+import os, sys, re
+from configparser import ConfigParser, ExtendedInterpolation
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+
+# Allow to interpolate section names
+class MyExtendedInterpolation(ExtendedInterpolation):
+	def before_get(self, parser, section, option, value, defaults):
+		defaults.maps.append({'section': section})
+		return super().before_get(parser, section, option, value, defaults)
+
+# which .ini keys are present and how they are named in .sh file
+LEGACY_MAP = {
+	"url" : "URL",
+	"directory" : "DIR",
+	"files" : "FILES",
+	"arguments" : "ARGS",
+}
+ini_file = "packages.ini"
+shell_file = "packages.sh"
+
+def make_prefix(s):
+	# bash variables should only contain letters and underscore
+	prefix = re.sub(r'\W+', '_', s, flags=re.A)
+	prefix = prefix.upper()
+	prefix += '_'
+	return prefix
+
+if __name__ == '__main__':
+	cp = ConfigParser(interpolation=MyExtendedInterpolation())
+
+	# load ini
+	try:
+		with open(f"{script_dir}/{ini_file}", 'r') as f:
+			cp.read_file(f)
+	except EnvironmentError:
+		print(f"Error reading '{ini_file}' file!")
+		sys.exit(1)
+
+	original_stdout = sys.stdout
+
+	# write to shell
+	try:
+		with open(f"{script_dir}/{shell_file}", 'w') as f:
+			sys.stdout = f
+			print("#!/bin/bash\n")
+			print("##### GENERATED FILE, DO NOT EDIT! ####")
+			print("# edit packages.ini and run ini2sh.py #")
+			print("#######################################\n\n")
+
+			# copy all ini sections
+			for section in cp.sections():
+				#print(f"#lib={section}")
+				#version = cp.get(section, "version")
+				#print(f"#ver={version}")
+				prefix = make_prefix(section)
+				for option in cp[section]:
+					# shell comment
+					if option == "comment":
+						value = cp.get(section, option)
+						print(f'# {value}')
+					# skip unneeded
+					if option not in LEGACY_MAP or not cp.get(section, option):
+						continue
+					param = LEGACY_MAP[option.lower()]
+					value = cp.get(section, option)
+					# arguments can span multiline
+					if option == "arguments":
+						value = value.replace("\n", " \\\n")
+					print(f'{prefix}{param}={value}')
+				print("")
+			sys.stdout = original_stdout
+	except EnvironmentError:
+		print(f"Error writing '{shell_file}' file!")
+		sys.exit(1)
+
+	print("Done.")

--- a/shared/packages.ini
+++ b/shared/packages.ini
@@ -4,27 +4,30 @@ directory = "${section}-${version}"
 [zlib]
 version = 1.3
 url = "https://zlib.net/fossils/zlib-${version}.tar.gz"
+anitya_id = 5303
 
 [libpng]
 version = 1.6.39
 url = "https://download.sourceforge.net/libpng/libpng-${version}.tar.xz"
+anitya_id = 15294
 
 [freetype]
 version = 2.13.0
-# Some mirrors give 404
-# url = "https://download.savannah.gnu.org/releases/freetype/freetype-${version}.tar.xz"
 url = "https://mirrors.sarata.com/non-gnu/freetype/freetype-${version}.tar.xz"
 arguments = "-DFT_DISABLE_BZIP2=ON -DFT_DISABLE_BROTLI=ON"
+anitya_id = 854
 
 [harfbuzz]
 version = 7.1.0
 url = "https://github.com/harfbuzz/harfbuzz/releases/download/${version}/harfbuzz-${version}.tar.xz"
 arguments = "-DHB_HAVE_FREETYPE=ON -DHB_BUILD_SUBSET=OFF"
+anitya_id = 1299
 
 [pixman]
 version = 0.42.2
 url = "https://cairographics.org/releases/pixman-${version}.tar.gz"
 arguments = "--disable-libpng --enable-dependency-tracking"
+anitya_id = 3648
 
 [expat]
 version_major = 2
@@ -35,14 +38,17 @@ version_url = ${version_major}_${version_minor}_${version_patch}
 url = "https://github.com/libexpat/libexpat/releases/download/R_${version_url}/expat-${version}.tar.bz2"
 arguments = "-DEXPAT_BUILD_TOOLS=OFF -DEXPAT_BUILD_EXAMPLES=OFF
 	-DEXPAT_BUILD_TESTS=OFF -DEXPAT_BUILD_DOCS=OFF -DEXPAT_SHARED_LIBS=OFF"
+anitya_id = 770
 
 [libogg]
 version = 1.3.5
 url = "https://downloads.xiph.org/releases/ogg/libogg-${version}.tar.xz"
+anitya_id = 1694
 
 [libvorbis]
 version = 1.3.7
 url = "https://downloads.xiph.org/releases/vorbis/libvorbis-${version}.tar.xz"
+anitya_id = 1758
 
 [tremor]
 version = 7c30a66346199f3f09017a09567c6c8a3a0eedc8
@@ -51,45 +57,54 @@ url = "https://gitlab.xiph.org/xiph/tremor/-/archive/${version}/tremor-${version
 [mpg123]
 version = 1.31.3
 url = "https://www.mpg123.de/download/mpg123-${version}.tar.bz2"
+anitya_id = 12413
 
 [libsndfile]
 version = 1.2.0
 url = "https://github.com/libsndfile/libsndfile/releases/download/${version}/libsndfile-${version}.tar.xz"
 arguments = "--disable-alsa --disable-sqlite --disable-full-suite --disable-external-libs --disable-mpeg"
+anitya_id = 13277
 
 [libxmp-lite]
 version = 4.5.0
 url = "https://github.com/libxmp/libxmp/releases/download/libxmp-${version}/libxmp-lite-${version}.tar.gz"
+anitya_id = 1784
 
 [speexdsp]
 version = 1.2.1
 url = "https://downloads.xiph.org/releases/speex/speexdsp-${version}.tar.gz"
 arguments = "--disable-sse --disable-neon"
+anitya_id = 8419
 
 [libsamplerate]
 version = 0.2.2
 url = "https://github.com/libsndfile/libsamplerate/releases/download/${version}/libsamplerate-${version}.tar.xz"
+anitya_id = 1716
 
 [wildmidi]
 version = 0.4.5
 url = "https://github.com/Mindwerks/wildmidi/archive/wildmidi-${version}.tar.gz"
 directory = "wildmidi-wildmidi-${version}"
 arguments = "-DWANT_PLAYER=OFF -DWANT_STATIC=ON"
+anitya_id = 9179
 
 [opus]
 version = 1.4
 url = "https://downloads.xiph.org/releases/opus/opus-${version}.tar.gz"
 arguments = "--disable-intrinsics --disable-extra-programs"
+anitya_id = 11081
 
 [opusfile]
 version = 0.12
 url = "https://github.com/xiph/opusfile/releases/download/v${version}/opusfile-${version}.tar.gz"
 arguments = "--disable-http --disable-examples"
+anitya_id = 10353
 
 [fluidsynth]
 version = 2.3.2
 url = "https://github.com/FluidSynth/fluidsynth/archive/refs/tags/v${version}.tar.gz"
 arguments = "-DLIB_SUFFIX=''"
+anitya_id = 10437
 
 [FluidLite]
 version = 57a0e74e708f699b13d7c85b28a4e1ff5b71887c
@@ -101,31 +116,36 @@ version = 3.11.2
 url = "https://github.com/nlohmann/json/archive/v${version}.tar.gz"
 directory = "json-${version}"
 arguments = "-DJSON_BuildTests=OFF"
+anitya_id = 11152
 
 [fmt]
 version = 9.1.0
 url = "https://github.com/fmtlib/fmt/releases/download/${version}/fmt-${version}.zip"
 arguments = "-DFMT_DOC=OFF -DFMT_TEST=OFF"
+anitya_id = 11526
 
 [inih]
 version = 57
 url = "https://github.com/benhoyt/inih/archive/refs/tags/r${version}.tar.gz"
 directory = "inih-r${version}"
+anitya_id = 11600
 
 [lhasa]
 version = 0.4.0
 url = "https://github.com/fragglet/lhasa/releases/download/v${version}/lhasa-${version}.tar.gz"
+anitya_id = 14822
 
 [ICU]
 version_major = 69
 version_minor = 1
-version_url = ${version_major}-${version_minor}
-version = ${version_major}_${version_minor}
-url = "https://github.com/unicode-org/icu/releases/download/release-${version_url}/icu4c-${version}-src.tgz"
+version = ${version_major}-${version_minor}
+version_src = ${version_major}_${version_minor}
+url = "https://github.com/unicode-org/icu/releases/download/release-${version}/icu4c-${version_src}-src.tgz"
 directory = "icu"
 arguments = "--enable-strict=no --disable-tests --disable-samples
-			--disable-dyload --disable-extras --disable-icuio
-			--with-data-packaging=static --disable-layout --disable-layoutex"
+	--disable-dyload --disable-extras --disable-icuio
+	--with-data-packaging=static --disable-layout --disable-layoutex"
+anitya_id = 16134
 
 [icudata]
 _ini_comment = empty on purpose, otherwise polluted by default section
@@ -136,9 +156,11 @@ files = "icudt*.dat"
 [SDL2]
 version = 2.26.5
 url = "https://libsdl.org/release/SDL2-${version}.tar.gz"
+anitya_id = 4779
 
 [SDL2_image]
 comment = only needed for lmu2png tool
 version = 2.6.3
 url = "https://libsdl.org/projects/SDL_image/release/SDL2_image-${version}.tar.gz"
 arguments = "--disable-jpg --disable-png-shared --disable-tif --disable-webp"
+anitya_id = 4782

--- a/shared/packages.ini
+++ b/shared/packages.ini
@@ -1,0 +1,144 @@
+[DEFAULT]
+directory = "${section}-${version}"
+
+[zlib]
+version = 1.3
+url = "https://zlib.net/fossils/zlib-${version}.tar.gz"
+
+[libpng]
+version = 1.6.39
+url = "https://download.sourceforge.net/libpng/libpng-${version}.tar.xz"
+
+[freetype]
+version = 2.13.0
+# Some mirrors give 404
+# url = "https://download.savannah.gnu.org/releases/freetype/freetype-${version}.tar.xz"
+url = "https://mirrors.sarata.com/non-gnu/freetype/freetype-${version}.tar.xz"
+arguments = "-DFT_DISABLE_BZIP2=ON -DFT_DISABLE_BROTLI=ON"
+
+[harfbuzz]
+version = 7.1.0
+url = "https://github.com/harfbuzz/harfbuzz/releases/download/${version}/harfbuzz-${version}.tar.xz"
+arguments = "-DHB_HAVE_FREETYPE=ON -DHB_BUILD_SUBSET=OFF"
+
+[pixman]
+version = 0.42.2
+url = "https://cairographics.org/releases/pixman-${version}.tar.gz"
+arguments = "--disable-libpng --enable-dependency-tracking"
+
+[expat]
+version_major = 2
+version_minor = 5
+version_patch = 0
+version = ${version_major}.${version_minor}.${version_patch}
+version_url = ${version_major}_${version_minor}_${version_patch}
+url = "https://github.com/libexpat/libexpat/releases/download/R_${version_url}/expat-${version}.tar.bz2"
+arguments = "-DEXPAT_BUILD_TOOLS=OFF -DEXPAT_BUILD_EXAMPLES=OFF
+	-DEXPAT_BUILD_TESTS=OFF -DEXPAT_BUILD_DOCS=OFF -DEXPAT_SHARED_LIBS=OFF"
+
+[libogg]
+version = 1.3.5
+url = "https://downloads.xiph.org/releases/ogg/libogg-${version}.tar.xz"
+
+[libvorbis]
+version = 1.3.7
+url = "https://downloads.xiph.org/releases/vorbis/libvorbis-${version}.tar.xz"
+
+[tremor]
+version = 7c30a66346199f3f09017a09567c6c8a3a0eedc8
+url = "https://gitlab.xiph.org/xiph/tremor/-/archive/${version}/tremor-${version}.tar.bz2"
+
+[mpg123]
+version = 1.31.3
+url = "https://www.mpg123.de/download/mpg123-${version}.tar.bz2"
+
+[libsndfile]
+version = 1.2.0
+url = "https://github.com/libsndfile/libsndfile/releases/download/${version}/libsndfile-${version}.tar.xz"
+arguments = "--disable-alsa --disable-sqlite --disable-full-suite --disable-external-libs --disable-mpeg"
+
+[libxmp-lite]
+version = 4.5.0
+url = "https://github.com/libxmp/libxmp/releases/download/libxmp-${version}/libxmp-lite-${version}.tar.gz"
+
+[speexdsp]
+version = 1.2.1
+url = "https://downloads.xiph.org/releases/speex/speexdsp-${version}.tar.gz"
+arguments = "--disable-sse --disable-neon"
+
+[libsamplerate]
+version = 0.2.2
+url = "https://github.com/libsndfile/libsamplerate/releases/download/${version}/libsamplerate-${version}.tar.xz"
+
+[wildmidi]
+version = 0.4.5
+url = "https://github.com/Mindwerks/wildmidi/archive/wildmidi-${version}.tar.gz"
+directory = "wildmidi-wildmidi-${version}"
+arguments = "-DWANT_PLAYER=OFF -DWANT_STATIC=ON"
+
+[opus]
+version = 1.4
+url = "https://downloads.xiph.org/releases/opus/opus-${version}.tar.gz"
+arguments = "--disable-intrinsics --disable-extra-programs"
+
+[opusfile]
+version = 0.12
+url = "https://github.com/xiph/opusfile/releases/download/v${version}/opusfile-${version}.tar.gz"
+arguments = "--disable-http --disable-examples"
+
+[fluidsynth]
+version = 2.3.2
+url = "https://github.com/FluidSynth/fluidsynth/archive/refs/tags/v${version}.tar.gz"
+arguments = "-DLIB_SUFFIX=''"
+
+[FluidLite]
+version = 57a0e74e708f699b13d7c85b28a4e1ff5b71887c
+url = "https://github.com/divideconcept/FluidLite/archive/${version}.zip"
+arguments = "-DFLUIDLITE_BUILD_STATIC=ON -DFLUIDLITE_BUILD_SHARED=OFF"
+
+[nlohmannjson]
+version = 3.11.2
+url = "https://github.com/nlohmann/json/archive/v${version}.tar.gz"
+directory = "json-${version}"
+arguments = "-DJSON_BuildTests=OFF"
+
+[fmt]
+version = 9.1.0
+url = "https://github.com/fmtlib/fmt/releases/download/${version}/fmt-${version}.zip"
+arguments = "-DFMT_DOC=OFF -DFMT_TEST=OFF"
+
+[inih]
+version = 57
+url = "https://github.com/benhoyt/inih/archive/refs/tags/r${version}.tar.gz"
+directory = "inih-r${version}"
+
+[lhasa]
+version = 0.4.0
+url = "https://github.com/fragglet/lhasa/releases/download/v${version}/lhasa-${version}.tar.gz"
+
+[ICU]
+version_major = 69
+version_minor = 1
+version_url = ${version_major}-${version_minor}
+version = ${version_major}_${version_minor}
+url = "https://github.com/unicode-org/icu/releases/download/release-${version_url}/icu4c-${version}-src.tgz"
+directory = "icu"
+arguments = "--enable-strict=no --disable-tests --disable-samples
+			--disable-dyload --disable-extras --disable-icuio
+			--with-data-packaging=static --disable-layout --disable-layoutex"
+
+[icudata]
+_ini_comment = empty on purpose, otherwise polluted by default section
+directory = 
+url = https://ci.easyrpg.org/job/icudata/lastSuccessfulBuild/artifact/icudata.tar.gz
+files = "icudt*.dat"
+
+[SDL2]
+version = 2.26.5
+url = "https://libsdl.org/release/SDL2-${version}.tar.gz"
+
+[SDL2_image]
+comment = only needed for lmu2png tool
+version = 2.6.3
+url = "https://libsdl.org/projects/SDL_image/release/SDL2_image-${version}.tar.gz"
+arguments = "--disable-jpg --disable-png-shared --disable-tif --disable-webp"

--- a/shared/packages.sh
+++ b/shared/packages.sh
@@ -1,154 +1,107 @@
 #!/bin/bash
 
-lib=zlib
-ver=1.3
-ZLIB_URL="https://zlib.net/fossils/$lib-$ver.tar.gz"
-ZLIB_DIR="$lib-$ver"
+##### GENERATED FILE, DO NOT EDIT! ####
+# edit packages.ini and run ini2sh.py #
+#######################################
 
-lib=libpng
-ver=1.6.39
-LIBPNG_URL="https://download.sourceforge.net/libpng/$lib-$ver.tar.xz"
-LIBPNG_DIR="$lib-$ver"
 
-lib=freetype
-ver=2.13.0
-#FREETYPE_URL="https://download.savannah.gnu.org/releases/$lib/$lib-$ver.tar.xz" Some mirrors give 404
-FREETYPE_URL="https://mirrors.sarata.com/non-gnu/$lib/$lib-$ver.tar.xz"
-FREETYPE_DIR="$lib-$ver"
+ZLIB_URL="https://zlib.net/fossils/zlib-1.3.tar.gz"
+ZLIB_DIR="zlib-1.3"
+
+LIBPNG_URL="https://download.sourceforge.net/libpng/libpng-1.6.39.tar.xz"
+LIBPNG_DIR="libpng-1.6.39"
+
+FREETYPE_URL="https://mirrors.sarata.com/non-gnu/freetype/freetype-2.13.0.tar.xz"
 FREETYPE_ARGS="-DFT_DISABLE_BZIP2=ON -DFT_DISABLE_BROTLI=ON"
+FREETYPE_DIR="freetype-2.13.0"
 
-lib=harfbuzz
-ver=7.1.0
-HARFBUZZ_URL="https://github.com/harfbuzz/harfbuzz/releases/download/$ver/$lib-$ver.tar.xz"
-HARFBUZZ_DIR="$lib-$ver"
+HARFBUZZ_URL="https://github.com/harfbuzz/harfbuzz/releases/download/7.1.0/harfbuzz-7.1.0.tar.xz"
 HARFBUZZ_ARGS="-DHB_HAVE_FREETYPE=ON -DHB_BUILD_SUBSET=OFF"
+HARFBUZZ_DIR="harfbuzz-7.1.0"
 
-lib=pixman
-ver=0.42.2
-PIXMAN_URL="https://cairographics.org/releases/$lib-$ver.tar.gz"
-PIXMAN_DIR="$lib-$ver"
+PIXMAN_URL="https://cairographics.org/releases/pixman-0.42.2.tar.gz"
 PIXMAN_ARGS="--disable-libpng --enable-dependency-tracking"
+PIXMAN_DIR="pixman-0.42.2"
 
-lib=expat
-ver=2.5.0
-EXPAT_URL="https://github.com/libexpat/libexpat/releases/download/R_${ver//./_}/$lib-$ver.tar.bz2"
-EXPAT_DIR="$lib-$ver"
-EXPAT_ARGS="-DEXPAT_BUILD_TOOLS=OFF -DEXPAT_BUILD_EXAMPLES=OFF -DEXPAT_BUILD_TESTS=OFF -DEXPAT_BUILD_DOCS=OFF -DEXPAT_SHARED_LIBS=OFF"
+EXPAT_URL="https://github.com/libexpat/libexpat/releases/download/R_2_5_0/expat-2.5.0.tar.bz2"
+EXPAT_ARGS="-DEXPAT_BUILD_TOOLS=OFF -DEXPAT_BUILD_EXAMPLES=OFF \
+-DEXPAT_BUILD_TESTS=OFF -DEXPAT_BUILD_DOCS=OFF -DEXPAT_SHARED_LIBS=OFF"
+EXPAT_DIR="expat-2.5.0"
 
-lib=libogg
-ver=1.3.5
-LIBOGG_URL="https://downloads.xiph.org/releases/ogg/$lib-$ver.tar.xz"
-LIBOGG_DIR="$lib-$ver"
+LIBOGG_URL="https://downloads.xiph.org/releases/ogg/libogg-1.3.5.tar.xz"
+LIBOGG_DIR="libogg-1.3.5"
 
-lib=libvorbis
-ver=1.3.7
-LIBVORBIS_URL="https://downloads.xiph.org/releases/vorbis/$lib-$ver.tar.xz"
-LIBVORBIS_DIR="$lib-$ver"
+LIBVORBIS_URL="https://downloads.xiph.org/releases/vorbis/libvorbis-1.3.7.tar.xz"
+LIBVORBIS_DIR="libvorbis-1.3.7"
 
-lib=tremor
-ver=7c30a66346199f3f09017a09567c6c8a3a0eedc8
-TREMOR_URL="https://gitlab.xiph.org/xiph/$lib/-/archive/$ver/$lib-$ver.tar.bz2"
-TREMOR_DIR="$lib-$ver"
+TREMOR_URL="https://gitlab.xiph.org/xiph/tremor/-/archive/7c30a66346199f3f09017a09567c6c8a3a0eedc8/tremor-7c30a66346199f3f09017a09567c6c8a3a0eedc8.tar.bz2"
+TREMOR_DIR="tremor-7c30a66346199f3f09017a09567c6c8a3a0eedc8"
 
-lib=mpg123
-ver=1.31.3
-MPG123_URL=https://www.mpg123.de/download/$lib-$ver.tar.bz2
-MPG123_DIR="$lib-$ver"
+MPG123_URL="https://www.mpg123.de/download/mpg123-1.31.3.tar.bz2"
+MPG123_DIR="mpg123-1.31.3"
 
-lib=libsndfile
-ver=1.2.0
-LIBSNDFILE_URL=https://github.com/libsndfile/libsndfile/releases/download/$ver/$lib-$ver.tar.xz
-LIBSNDFILE_DIR="$lib-$ver"
+LIBSNDFILE_URL="https://github.com/libsndfile/libsndfile/releases/download/1.2.0/libsndfile-1.2.0.tar.xz"
 LIBSNDFILE_ARGS="--disable-alsa --disable-sqlite --disable-full-suite --disable-external-libs --disable-mpeg"
+LIBSNDFILE_DIR="libsndfile-1.2.0"
 
-lib=libxmp-lite
-ver=4.5.0
-LIBXMP_LITE_URL="https://github.com/libxmp/libxmp/releases/download/libxmp-$ver/$lib-$ver.tar.gz"
-LIBXMP_LITE_DIR="$lib-$ver"
+LIBXMP_LITE_URL="https://github.com/libxmp/libxmp/releases/download/libxmp-4.5.0/libxmp-lite-4.5.0.tar.gz"
+LIBXMP_LITE_DIR="libxmp-lite-4.5.0"
 
-lib=speexdsp
-ver=1.2.1
-SPEEXDSP_URL="https://downloads.xiph.org/releases/speex/$lib-$ver.tar.gz"
-SPEEXDSP_DIR="$lib-$ver"
+SPEEXDSP_URL="https://downloads.xiph.org/releases/speex/speexdsp-1.2.1.tar.gz"
 SPEEXDSP_ARGS="--disable-sse --disable-neon"
+SPEEXDSP_DIR="speexdsp-1.2.1"
 
-lib=libsamplerate
-ver=0.2.2
-LIBSAMPLERATE_URL="https://github.com/libsndfile/libsamplerate/releases/download/$ver/$lib-$ver.tar.xz"
-LIBSAMPLERATE_DIR="$lib-$ver"
+LIBSAMPLERATE_URL="https://github.com/libsndfile/libsamplerate/releases/download/0.2.2/libsamplerate-0.2.2.tar.xz"
+LIBSAMPLERATE_DIR="libsamplerate-0.2.2"
 
-lib=wildmidi
-ver=0.4.5
-WILDMIDI_URL="https://github.com/Mindwerks/wildmidi/archive/$lib-$ver.tar.gz"
-WILDMIDI_DIR="$lib-$lib-$ver"
+WILDMIDI_URL="https://github.com/Mindwerks/wildmidi/archive/wildmidi-0.4.5.tar.gz"
+WILDMIDI_DIR="wildmidi-wildmidi-0.4.5"
 WILDMIDI_ARGS="-DWANT_PLAYER=OFF -DWANT_STATIC=ON"
 
-lib=opus
-ver=1.4
-OPUS_URL="https://downloads.xiph.org/releases/$lib/$lib-$ver.tar.gz"
-OPUS_DIR="$lib-$ver"
+OPUS_URL="https://downloads.xiph.org/releases/opus/opus-1.4.tar.gz"
 OPUS_ARGS="--disable-intrinsics --disable-extra-programs"
+OPUS_DIR="opus-1.4"
 
-lib=opusfile
-ver=0.12
-OPUSFILE_URL="https://github.com/xiph/opusfile/releases/download/v$ver/$lib-$ver.tar.gz"
-OPUSFILE_DIR="$lib-$ver"
+OPUSFILE_URL="https://github.com/xiph/opusfile/releases/download/v0.12/opusfile-0.12.tar.gz"
 OPUSFILE_ARGS="--disable-http --disable-examples"
+OPUSFILE_DIR="opusfile-0.12"
 
-lib=fluidsynth
-ver=2.3.2
-FLUIDSYNTH_URL="https://github.com/FluidSynth/fluidsynth/archive/refs/tags/v$ver.tar.gz"
-FLUIDSYNTH_DIR="$lib-$ver"
+FLUIDSYNTH_URL="https://github.com/FluidSynth/fluidsynth/archive/refs/tags/v2.3.2.tar.gz"
 FLUIDSYNTH_ARGS="-DLIB_SUFFIX=''"
+FLUIDSYNTH_DIR="fluidsynth-2.3.2"
 
-lib=FluidLite
-ver=57a0e74e708f699b13d7c85b28a4e1ff5b71887c
-FLUIDLITE_URL="https://github.com/divideconcept/$lib/archive/$ver.zip"
-FLUIDLITE_DIR="$lib-$ver"
+FLUIDLITE_URL="https://github.com/divideconcept/FluidLite/archive/57a0e74e708f699b13d7c85b28a4e1ff5b71887c.zip"
 FLUIDLITE_ARGS="-DFLUIDLITE_BUILD_STATIC=ON -DFLUIDLITE_BUILD_SHARED=OFF"
+FLUIDLITE_DIR="FluidLite-57a0e74e708f699b13d7c85b28a4e1ff5b71887c"
 
-lib=json
-ver=3.11.2
-NLOHMANNJSON_URL="https://github.com/nlohmann/$lib/archive/v$ver.tar.gz"
-NLOHMANNJSON_DIR=$lib-$ver
+NLOHMANNJSON_URL="https://github.com/nlohmann/json/archive/v3.11.2.tar.gz"
+NLOHMANNJSON_DIR="json-3.11.2"
 NLOHMANNJSON_ARGS="-DJSON_BuildTests=OFF"
 
-lib=fmt
-ver=9.1.0
-FMT_URL="https://github.com/fmtlib/fmt/releases/download/$ver/$lib-$ver.zip"
-FMT_DIR="$lib-$ver"
+FMT_URL="https://github.com/fmtlib/fmt/releases/download/9.1.0/fmt-9.1.0.zip"
 FMT_ARGS="-DFMT_DOC=OFF -DFMT_TEST=OFF"
+FMT_DIR="fmt-9.1.0"
 
-lib=inih
-ver=r57
-INIH_URL="https://github.com/benhoyt/inih/archive/refs/tags/$ver.tar.gz"
-INIH_DIR="$lib-$ver"
+INIH_URL="https://github.com/benhoyt/inih/archive/refs/tags/r57.tar.gz"
+INIH_DIR="inih-r57"
 
-lib=lhasa
-ver=0.4.0
-LHASA_URL="https://github.com/fragglet/lhasa/releases/download/v$ver/$lib-$ver.tar.gz"
-LHASA_DIR="$lib-$ver"
+LHASA_URL="https://github.com/fragglet/lhasa/releases/download/v0.4.0/lhasa-0.4.0.tar.gz"
+LHASA_DIR="lhasa-0.4.0"
 
-lib=ICU
-ver=69.1
-ICU_URL=https://github.com/unicode-org/icu/releases/download/release-${ver//./-}/icu4c-${ver//./_}-src.tgz
+ICU_URL="https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-src.tgz"
 ICU_DIR="icu"
 ICU_ARGS="--enable-strict=no --disable-tests --disable-samples \
-	--disable-dyload --disable-extras --disable-icuio \
-	--with-data-packaging=static --disable-layout --disable-layoutex"
+--disable-dyload --disable-extras --disable-icuio \
+--with-data-packaging=static --disable-layout --disable-layoutex"
 
-lib=icudata
 ICUDATA_URL=https://ci.easyrpg.org/job/icudata/lastSuccessfulBuild/artifact/icudata.tar.gz
-ICUDATA_FILES=icudt*.dat
+ICUDATA_FILES="icudt*.dat"
 
-lib=SDL2
-ver=2.26.5
-SDL2_URL="https://libsdl.org/release/$lib-$ver.tar.gz"
-SDL2_DIR="$lib-$ver"
+SDL2_URL="https://libsdl.org/release/SDL2-2.26.5.tar.gz"
+SDL2_DIR="SDL2-2.26.5"
 
 # only needed for lmu2png tool
-lib=SDL2_image
-ver=2.6.3
-SDL2_IMAGE_URL="https://www.libsdl.org/projects/SDL_image/release/$lib-$ver.tar.gz"
-SDL2_IMAGE_DIR="$lib-$ver"
+SDL2_IMAGE_URL="https://libsdl.org/projects/SDL_image/release/SDL2_image-2.6.3.tar.gz"
 SDL2_IMAGE_ARGS="--disable-jpg --disable-png-shared --disable-tif --disable-webp"
+SDL2_IMAGE_DIR="SDL2_image-2.6.3"
+

--- a/shared/updater.py
+++ b/shared/updater.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import os, sys
+from configparser import ConfigParser, ExtendedInterpolation
+import requests
+from packaging import version
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+
+# Allow to interpolate section names
+class MyExtendedInterpolation(ExtendedInterpolation):
+	def before_get(self, parser, section, option, value, defaults):
+		defaults.maps.append({'section': section})
+		return super().before_get(parser, section, option, value, defaults)
+
+ini_file = "packages.ini"
+pr_file = "pr-body.txt"
+
+def query_anitya(id):
+	url = 'https://release-monitoring.org/api/project/'
+	headers = { 'Accept': 'application/json' }
+	response = requests.get(url=url + str(id), headers=headers)
+
+	if not response:
+		print("Error querying Anitya!")
+		return None
+	return response.json()["version"]
+
+
+if __name__ == '__main__':
+	cp = ConfigParser(interpolation=MyExtendedInterpolation())
+
+	try:
+		with open(f"{script_dir}/{ini_file}", 'r') as f:
+			cp.read_file(f)
+	except EnvironmentError:
+		print(f"Error reading '{ini_file}' file!")
+		sys.exit(1)
+
+	# check for updates
+	version_map = {}
+	for lib in cp.sections():
+		if not cp.has_option(lib, "anitya_id"):
+			print(f"Skipping {lib}, no Anitya id.")
+			continue
+		else:
+			print(f"Checking {lib}: ", end='')
+		ver = query_anitya(cp.getint(lib, "anitya_id"))
+		if ver:
+			print(f"{ver}")
+			version_map[lib] = ver
+
+	print("Updating: ", end='')
+	updates = []
+	comma = ""
+	for lib, ver in version_map.items():
+		old_ver = cp.get(lib, "version")
+		if version.parse(ver) <= version.parse(old_ver):
+			continue
+		else:
+			print(f"{comma}{lib}", end='')
+			comma = ", "
+		# check for special handling
+		if cp.has_option(lib, "version_major"):
+			v = ver.split(".") # expat
+			if v[0] == ver:
+				v = ver.split("-") # ICU
+			cp.set(lib, "version_major", v[0])
+			if cp.has_option(lib, "version_minor"):
+				cp.set(lib, "version_minor", v[1])
+				if cp.has_option(lib, "version_patch"):
+					cp.set(lib, "version_patch", v[2])
+		else:
+			cp.set(lib, "version", ver)
+		updates.append(f" - **{lib}**: {old_ver} → {ver}")
+	print()
+
+	try:
+		with open(f"{script_dir}/{ini_file}", 'w') as f:
+			cp.write(f)
+	except EnvironmentError:
+		print(f"Error writing '{ini_file}' file!")
+		sys.exit(1)
+
+	# generate pull request body
+	if os.getenv('GITHUB_ACTIONS', "false") == "true":
+		try:
+			with open(f"{script_dir}/../{pr_file}", 'w') as f:
+				f.write("The following libraries shall be updated:\n")
+				f.write('\n'.join(updates))
+				f.write("\n\nThis pull request will adapt to changes made in the repository.\n")
+		except EnvironmentError:
+			print(f"Error writing '{pr_file}' file!")
+			sys.exit(1)
+
+	print("All done.")


### PR DESCRIPTION
### This is actually 2 changes at once:
- ini for library definitions, makes scripting easier
- updater script using anitya, automatically run by github actions every week

### Some nice features:
- Uses a supercharged ini format with replacements
- adding libraries to/updating `packages.sh` is easier
- no more missed library updates
  - will open a pull request for each bunch, can stay open until issues are resolved
  - parallel updates (in other PRs) will be recognized once applied
- no functional change for existing scripts

### Whats missing:
- Automated PR builders on jenkins, to find breakage

### Here is an example of such pull request:
https://github.com/carstene1ns/easyrpg-buildscripts/pull/2
(I have pushed an update to harfbuzz and freetype to master branch, these have been removed)
![2023-11-10T04:13:39,358750502+01:00](https://github.com/EasyRPG/buildscripts/assets/4691314/77d758bc-8750-4e8a-b7e5-9e4654ed4d41)
