### PR TITLE
Set arm64 explicitly for libpng

### DIFF
--- a/3ds/2_build_toolchain.sh
+++ b/3ds/2_build_toolchain.sh
@@ -84,6 +84,7 @@ function set_build_flags {
 	export LDFLAGS="$ARCH_FLAGS -L$PLATFORM_PREFIX/lib -L$DEVKITPRO/libctru/lib"
 	export LIBS="-lctru"
 	export CMAKE_SYSTEM_NAME="Generic"
+	export CMAKE_EXTRA_ARGS="-DCMAKE_SYSTEM_PROCESSOR=arm"
 
 	make_meson_cross 3ds > meson-cross.txt
 }

--- a/android/2_build_toolchain.sh
+++ b/android/2_build_toolchain.sh
@@ -86,13 +86,15 @@ function build() {
 
 	export CFLAGS="-no-integrated-as -g0 -O2 -fPIC $5"
 	export CXXFLAGS="$CFLAGS"
-	export CPPFLAGS="-I$PLATFORM_PREFIX/include -I$NDK_ROOT/sources/android/cpufeatures"
+	export CPPFLAGS="-I$PLATFORM_PREFIX/include -I$ANDROID_NDK/sources/android/cpufeatures"
 	export LDFLAGS="-L$PLATFORM_PREFIX/lib"
 	unset PKG_CONFIG_PATH
 	export PKG_CONFIG_LIBDIR=$PLATFORM_PREFIX/lib/pkgconfig
 	export TARGET_HOST="$4"
 	export CC="clang -target ${TARGET_HOST}${TARGET_API}"
 	export CXX="clang++ -target ${TARGET_HOST}${TARGET_API}"
+
+	export CMAKE_EXTRA_ARGS="-DCMAKE_ANDROID_ARCH_ABI=$2 -DCMAKE_ANDROID_API=$TARGET_API"
 
 	mkdir -p $PLATFORM_PREFIX
 	make_meson_cross "${TARGET_HOST}${TARGET_API}" > $PLATFORM_PREFIX/meson-cross.txt
@@ -123,7 +125,7 @@ function build() {
 }
 
 export SDK_ROOT=$WORKSPACE/android-sdk
-export NDK_ROOT=$SDK_ROOT/ndk/21.4.7075529
+export ANDROID_NDK=$SDK_ROOT/ndk/21.4.7075529
 
 export MAKEFLAGS="-j${nproc:-2}"
 
@@ -133,13 +135,16 @@ cd $WORKSPACE
 install_lib_icu_native
 
 # Setup PATH
-NDK_PATH=$NDK_ROOT/toolchains/llvm/prebuilt/$NDK_ARCH/bin
-PATH=$NDK_ROOT:$NDK_PATH:$SDK_ROOT/tools:$PATH
+NDK_PATH=$ANDROID_NDK/toolchains/llvm/prebuilt/$NDK_ARCH/bin
+PATH=$ANDROID_NDK:$NDK_PATH:$SDK_ROOT/tools:$PATH
 
 export OLD_PATH=$PATH
 
 # Correctly detected mmap support in mpg123
 export ac_cv_func_mmap_fixed_mapped=yes
+
+# Target Android with CMake
+export CMAKE_SYSTEM_NAME=Android
 
 # ARMeabi-v7a
 build "ARMeabi-v7a" "armeabi-v7a" "arm" "armv7a-linux-androideabi" "-march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3"

--- a/emscripten/1_download_library.sh
+++ b/emscripten/1_download_library.sh
@@ -43,8 +43,8 @@ else
 	touch .emscripten
 
 	# Download and install the latest SDK tools and set up the compiler configuration to point to it.
-	./emsdk install 3.1.49
-	./emsdk activate 3.1.49
+	./emsdk install 3.1.65
+	./emsdk activate 3.1.65
 
 	# Set the current Emscripten path
 	source ./emsdk_env.sh

--- a/ios/2_build_toolchain.sh
+++ b/ios/2_build_toolchain.sh
@@ -29,8 +29,8 @@ function set_build_flags {
 	# $1: Arch (either armv7 or arm64)
 	# $2: host for configure
 	# $3: additional cpp flags
-	CLANG="xcrun --sdk iphoneos clang"
-	CLANGXX="xcrun --sdk iphoneos clang++"
+	CLANG=`xcrun -f --sdk iphoneos clang`
+	CLANGXX=`xcrun -f --sdk iphoneos clang++`
 	ARCH="-arch $1"
 	SDKPATH=`xcrun -sdk iphoneos --show-sdk-path`
 	PLATFORM_PREFIX="$WORKSPACE/$1"
@@ -46,6 +46,8 @@ function set_build_flags {
 	# ICU include is required for arm64
 	export CPPFLAGS="-I$PLATFORM_PREFIX/include -I$WORKSPACE/icu/source/common"
 	export LDFLAGS="-L$PLATFORM_PREFIX/lib $ARCH -miphoneos-version-min=9.0 -isysroot $SDKPATH"
+
+	export CMAKE_EXTRA_ARGS="-DCMAKE_OSX_ARCHITECTURES=$1"
 
 	export PKG_CONFIG_PATH=$PLATFORM_PREFIX/lib/pkgconfig
 	export PKG_CONFIG_LIBDIR=$PKG_CONFIG_PATH

--- a/macos/2_build_toolchain.sh
+++ b/macos/2_build_toolchain.sh
@@ -29,8 +29,8 @@ function set_build_flags() {
 	# $1: Arch (either x86_64 or arm64)
 	# $2: host for configure
 	# $3: additional cpp flags
-	CLANG="xcrun --sdk macosx clang"
-	CLANGXX="xcrun --sdk macosx clang++"
+	CLANG=`xcrun -f --sdk macosx clang`
+	CLANGXX=`xcrun -f --sdk macosx clang++`
 	ARCH="-arch $1"
 	SDKPATH=`xcrun -sdk macosx --show-sdk-path`
 	PLATFORM_PREFIX="$WORKSPACE/$1"
@@ -47,6 +47,7 @@ function set_build_flags() {
 	export LDFLAGS="-L$PLATFORM_PREFIX/lib $ARCH -mmacosx-version-min=10.9 -isysroot $SDKPATH"
 
 	export MACOSX_DEPLOYMENT_TARGET=10.9
+	export CMAKE_EXTRA_ARGS="-DCMAKE_OSX_ARCHITECTURES=$1"
 
 	export PKG_CONFIG_PATH=$PLATFORM_PREFIX/lib/pkgconfig
 	export PKG_CONFIG_LIBDIR=$PKG_CONFIG_PATH

--- a/switch/2_build_toolchain.sh
+++ b/switch/2_build_toolchain.sh
@@ -73,6 +73,7 @@ function set_build_flags {
 	export LDFLAGS="$ARCH_FLAGS -L$PLATFORM_PREFIX/lib -L$DEVKITPRO/libnx/lib"
 	export LIBS="-lnx"
 	export CMAKE_SYSTEM_NAME="Generic"
+	export CMAKE_EXTRA_ARGS="-DCMAKE_SYSTEM_PROCESSOR=arm64"
 
 	make_meson_cross switch > meson-cross.txt
 }

--- a/vita/2_build_toolchain.sh
+++ b/vita/2_build_toolchain.sh
@@ -62,6 +62,7 @@ function set_build_flags {
 	export CXXFLAGS="$CFLAGS"
 	export CPPFLAGS="-DPSP2"
 	export CMAKE_SYSTEM_NAME="Generic"
+	export CMAKE_EXTRA_ARGS="-DCMAKE_SYSTEM_PROCESSOR=arm64"
 
 	make_meson_cross vita > $PLATFORM_PREFIX/meson-cross.txt
 }


### PR DESCRIPTION
Otherwise gives linker errors for missing neon functions

I have no idea why this is suddenly broken. Only tested on "Switch". Hope this fixes it for all of them as the error is the same on all arm64 targets.

---

EDIT: Does not work for Android and macOS.