### PR TITLE
3DS: Disable Mutex code in ICU because it crashes

### DIFF
--- a/3ds/2_build_toolchain.sh
+++ b/3ds/2_build_toolchain.sh
@@ -60,6 +60,8 @@ if [ ! -f .patches-applied ]; then
 
 	# Fix icu build
 	patch -Np0 < $SCRIPT_DIR/icu-3ds.patch
+	# Patch mutex support out
+	patch -Np0 < $SCRIPT_DIR/icu-3ds-no-mutex.patch
 
 	touch .patches-applied
 fi

--- a/3ds/icu-3ds-no-mutex.patch
+++ b/3ds/icu-3ds-no-mutex.patch
@@ -1,0 +1,126 @@
+diff -Naur icu-orig/source/common/umutex.cpp icu/source/common/umutex.cpp
+--- icu-orig/source/common/umutex.cpp	2024-09-01 18:41:49.755849773 +0200
++++ icu/source/common/umutex.cpp	2024-09-01 18:42:05.278763995 +0200
+@@ -44,20 +44,25 @@
+  *************************************************************************************************/
+ 
+ namespace {
++#if 0
+ std::mutex *initMutex;
+ std::condition_variable *initCondition;
++#endif
+ 
+ // The ICU global mutex.
+ // Used when ICU implementation code passes nullptr for the mutex pointer.
+ UMutex globalMutex;
+ 
++#if 0
+ std::once_flag initFlag;
+ std::once_flag *pInitFlag = &initFlag;
++#endif
+ 
+ }  // Anonymous namespace
+ 
+ U_CDECL_BEGIN
+ static UBool U_CALLCONV umtx_cleanup() {
++#if 0
+     initMutex->~mutex();
+     initCondition->~condition_variable();
+     UMutex::cleanup();
+@@ -66,17 +71,20 @@
+     // Do not use this trick anywhere else in ICU; use umtx_initOnce, not std::call_once().
+     pInitFlag->~once_flag();
+     pInitFlag = new(&initFlag) std::once_flag();
++#endif
+     return true;
+ }
+ 
+ static void U_CALLCONV umtx_init() {
++#if 0
+     initMutex = STATIC_NEW(std::mutex);
+     initCondition = STATIC_NEW(std::condition_variable);
+     ucln_common_registerCleanup(UCLN_COMMON_MUTEX, umtx_cleanup);
++#endif
+ }
+ U_CDECL_END
+ 
+-
++#if 0
+ std::mutex *UMutex::getMutex() {
+     std::mutex *retPtr = fMutex.load(std::memory_order_acquire);
+     if (retPtr == nullptr) {
+@@ -106,7 +114,7 @@
+     }
+     gListHead = nullptr;
+ }
+-
++#endif
+ 
+ U_CAPI void  U_EXPORT2
+ umtx_lock(UMutex *mutex) {
+@@ -143,6 +151,7 @@
+ //
+ U_COMMON_API UBool U_EXPORT2
+ umtx_initImplPreInit(UInitOnce &uio) {
++#if 0
+     std::call_once(*pInitFlag, umtx_init);
+     std::unique_lock<std::mutex> lock(*initMutex);
+     if (umtx_loadAcquire(uio.fState) == 0) {
+@@ -157,6 +166,8 @@
+         U_ASSERT(uio.fState == 2);
+         return false;
+     }
++#endif
++    return true;
+ }
+ 
+ 
+@@ -168,11 +179,13 @@
+ 
+ U_COMMON_API void U_EXPORT2
+ umtx_initImplPostInit(UInitOnce &uio) {
++#if 0
+     {
+         std::unique_lock<std::mutex> lock(*initMutex);
+         umtx_storeRelease(uio.fState, 2);
+     }
+     initCondition->notify_all();
++#endif
+ }
+ 
+ U_NAMESPACE_END
+diff '--color=auto' -Naur icu-orig/source/common/umutex.h icu/source/common/umutex.h
+--- icu-orig/source/common/umutex.h	2024-09-01 18:41:49.732517070 +0200
++++ icu/source/common/umutex.h	2024-09-01 18:42:05.278763995 +0200
+@@ -227,15 +227,22 @@
+ 
+     // requirements for C++ BasicLockable, allows UMutex to work with std::lock_guard
+     void lock() {
++#if 0
+         std::mutex *m = fMutex.load(std::memory_order_acquire);
+         if (m == nullptr) { m = getMutex(); }
+         m->lock();
++#endif
++    }
++    void unlock() {
++#if 0
++        fMutex.load(std::memory_order_relaxed)->unlock();
++#endif
+     }
+-    void unlock() { fMutex.load(std::memory_order_relaxed)->unlock(); }
+ 
+     static void cleanup();
+ 
+ private:
++#if 0
+     alignas(std::mutex) char fStorage[sizeof(std::mutex)] {};
+     std::atomic<std::mutex *> fMutex { nullptr };
+ 
+@@ -250,6 +257,7 @@
+      * be nullptr.
+      */
+     std::mutex *getMutex();
++#endif
+ };
+ 
+ 


### PR DESCRIPTION
Same issue as on the Wii with broken std::mutex implementation.

We only use ICU from a single thread.
A better patch should implement it with mutexes provided by ctrulib