### PR TITLE
Windows: Downgrade fmtlib to the previous version to fix build error in fmt::styled

### DIFF
--- a/windows/helper/prepare.cmd
+++ b/windows/helper/prepare.cmd
@@ -11,6 +11,10 @@ IF EXIST vcpkg (
 :: Build vcpkg
 call bootstrap-vcpkg.bat
 
+:: Revert fmtlib to the previous version because fmt::styled does not compile
+:: Remove this when the next fmtlib version is released
+git restore -s 50ca16008cebab427e90a98f8ffc34208b215dba ports/fmt
+
 :: Optimize the debug libraries
 copy ..\helper\windows.cmake scripts\toolchains\windows.cmake
 


### PR DESCRIPTION
This was fixed in fmt months ago but there was no new release since then... Lets use an older version until they fix this.

This reverts back to 10.2.1, the previous version on vcpkg.

Fix #183