### PR TITLE
Android & emscripten: Make buildscript work on m1 (arm64) macOS

### DIFF
--- a/android/1_download_library.sh
+++ b/android/1_download_library.sh
@@ -38,7 +38,7 @@ else
 	exit 1
 fi
 
-SDK_VERSION="9477386_latest"
+SDK_VERSION="11076708_latest"
 SDK_URL="https://dl.google.com/android/repository/commandlinetools-${SDK_PLATFORM}-${SDK_VERSION}.zip"
 curl -sSLOR "$SDK_URL"
 unzip commandlinetools-${SDK_PLATFORM}-${SDK_VERSION}.zip
@@ -53,12 +53,12 @@ msg " [2] Installing SDK and Platform-tools"
 # Otherwise installed to the wrong directory
 cd android-sdk
 
-# Android SDK Build-tools, revision 33.0.0
-echo "y" | ./cmdline-tools/latest/bin/sdkmanager --verbose "build-tools;33.0.0"
+# Android SDK Build-tools, revision 36.0.0
+echo "y" | ./cmdline-tools/latest/bin/sdkmanager --verbose "build-tools;36.0.0"
 # Android SDK Platform-tools
 echo "y" | ./cmdline-tools/latest/bin/sdkmanager --verbose "platform-tools"
-# SDK Platform Android 13, API 33
-echo "y" | ./cmdline-tools/latest/bin/sdkmanager --verbose "platforms;android-33"
+# SDK Platform Android 15, API 35
+echo "y" | ./cmdline-tools/latest/bin/sdkmanager --verbose "platforms;android-35"
 # Android Support Library Repository
 echo "y" | ./cmdline-tools/latest/bin/sdkmanager --verbose "extras;android;m2repository"
 # Google Repository
@@ -68,7 +68,7 @@ echo "y" | ./cmdline-tools/latest/bin/sdkmanager --verbose "cmake;3.22.1"
 
 msg " [3] Installing Android NDK"
 
-echo "y" | ./cmdline-tools/latest/bin/sdkmanager --verbose "ndk;21.4.7075529"
+echo "y" | ./cmdline-tools/latest/bin/sdkmanager --verbose "ndk;24.0.8215888"
 
 cd ..
 

--- a/android/2_build_toolchain.sh
+++ b/android/2_build_toolchain.sh
@@ -59,13 +59,12 @@ function build() {
 	# $2: Toolchain architecture
 	# $3: Android arch
 	# $4: host for configure
-	# $5: additional CPP flags
 
 	cd $WORKSPACE
 
 	echo "Preparing $1 toolchain"
 
-	export TARGET_API=16
+	export TARGET_API=19
 	if [ "$3" = "arm64" ]; then
 		# Minimum API 21 on ARM64
 		export TARGET_API=21
@@ -84,7 +83,7 @@ function build() {
 	export NM=$NDK_PATH/llvm-nm
 	export RANLIB=$NDK_PATH/llvm-ranlib
 
-	export CFLAGS="-no-integrated-as -g0 -O2 -fPIC $5"
+	export CFLAGS="-g0 -O2 -fPIC"
 	export CXXFLAGS="$CFLAGS"
 	export CPPFLAGS="-I$PLATFORM_PREFIX/include -I$ANDROID_NDK/sources/android/cpufeatures"
 	export LDFLAGS="-L$PLATFORM_PREFIX/lib"
@@ -125,7 +124,7 @@ function build() {
 }
 
 export SDK_ROOT=$WORKSPACE/android-sdk
-export ANDROID_NDK=$SDK_ROOT/ndk/21.4.7075529
+export ANDROID_NDK=$SDK_ROOT/ndk/24.0.8215888
 
 export MAKEFLAGS="-j${nproc:-2}"
 
@@ -147,13 +146,13 @@ export ac_cv_func_mmap_fixed_mapped=yes
 export CMAKE_SYSTEM_NAME=Android
 
 # ARMeabi-v7a
-build "ARMeabi-v7a" "armeabi-v7a" "arm" "armv7a-linux-androideabi" "-march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3"
+build "ARMeabi-v7a" "armeabi-v7a" "arm" "armv7a-linux-androideabi"
 
 # arm64-v8a
-build "AArch64" "arm64-v8a" "arm64" "aarch64-linux-android" ""
+build "AArch64" "arm64-v8a" "arm64" "aarch64-linux-android"
 
 # x86
-build "x86" "x86" "x86" "i686-linux-android" ""
+build "x86" "x86" "x86" "i686-linux-android"
 
 # x86_64
-build "x86_64" "x86_64" "x86_64" "x86_64-linux-android" ""
+build "x86_64" "x86_64" "x86_64" "x86_64-linux-android"

--- a/emscripten/1_download_library.sh
+++ b/emscripten/1_download_library.sh
@@ -25,14 +25,6 @@ if hash emcc >/dev/null 2>&1; then
 else
 	echo "Preparing portable SDK"
 
-	if [ $os = "Darwin" ] ; then
-		if [ "$(uname -m)" = "arm64" ] ; then
-			echo "macOS arm64 requires a preinstalled emscripten."
-			echo "Run 'brew install emscripten' to install it."
-			exit 1
-		fi
-	fi
-
 	rm -rf emsdk-portable
 	git_clone https://github.com/emscripten-core/emsdk.git emsdk-portable
 
@@ -43,8 +35,8 @@ else
 	touch .emscripten
 
 	# Download and install the latest SDK tools and set up the compiler configuration to point to it.
-	./emsdk install 3.1.74
-	./emsdk activate 3.1.74
+	./emsdk install 4.0.5
+	./emsdk activate 4.0.5
 
 	# Set the current Emscripten path
 	source ./emsdk_env.sh

--- a/emscripten/2_build_toolchain.sh
+++ b/emscripten/2_build_toolchain.sh
@@ -29,6 +29,15 @@ if [ ! -f .patches-applied ]; then
 		autoreconf -fi
 	)
 
+	# Make wasm32-unknown-emscripten available
+	(cd $LIBOGG_DIR
+		autoreconf -fi
+	)
+
+	(cd $LIBVORBIS_DIR
+		autoreconf -fi
+	)
+
 	# disable unsupported compiler flags by emcc clang in libogg
 	perl -pi -e 's/-O20/-g0 -O2/g' $LIBOGG_DIR/configure
 
@@ -68,6 +77,8 @@ function set_build_flags {
 	export EM_PKG_CONFIG_PATH="$PLATFORM_PREFIX/lib/pkgconfig"
 	export CMAKE_EXTRA_ARGS="-DCMAKE_FIND_ROOT_PATH=$PLATFORM_PREFIX"
 
+	export TARGET_HOST="wasm32-unknown-emscripten"
+
 	# force mmap support in mpg123 (actually unused, but needed for building)
 	export ac_cv_func_mmap_fixed_mapped=yes
 
@@ -88,12 +99,6 @@ cd $WORKSPACE
 
 # Install libraries
 set_build_flags
-
-if [ $os = "Darwin" ] ; then
-	# Workaround wrong libtool being detected
-	# Do not use this on Linux, fails with autoconf 2.69
-	export TARGET_HOST="asmjs-unknown-emscripten"
-fi
 
 install_lib_cmake $ZLIB_DIR $ZLIB_ARGS
 install_lib_cmake $LIBPNG_DIR $LIBPNG_ARGS
@@ -116,13 +121,7 @@ install_lib_cmake $NLOHMANNJSON_DIR $NLOHMANNJSON_ARGS
 install_lib_meson $INIH_DIR $INIH_ARGS
 #install_lib $LHASA_DIR $LHASA_ARGS
 install_lib_cmake $FMT_DIR $FMT_ARGS
-
-# emscripten TARGET_HOST does not work for all libraries but SDL2 requires it
-export TARGET_HOST="asmjs-unknown-emscripten"
-rm -f config.cache
 install_lib $SDL2_DIR $SDL2_ARGS --disable-assembly --disable-threads --disable-cpuinfo
-rm -f config.cache
-unset TARGET_HOST
 
 install_lib_icu_cross
 icu_force_data_install


### PR DESCRIPTION
Requires a newer NDK version which drops support for older Android SDKs <19.

Though this is no problem for us as we already require API Level 20.

---

For context: fdelapena set up a m1 mac. This will replace my awful, slow macOS builder.

The m1 is fast so I consider also offloading the Android build to it. The Android build is especially bad on our slow VPS because it compiles 4 times.

(then the main builder will only build Linux and emscripten)

This is a draft until the migration is done.

---

Emscripten was fixed because I finally have a test system available xD