### PR TITLE
Vita: Disable ICU mutex code (deadlocks on startup), bump libpng

### DIFF
--- a/shared/libpng-custom-cc.patch
+++ b/shared/libpng-custom-cc.patch
@@ -1,6 +1,6 @@
-diff -Nur libpng-1.6.39-orig/scripts/genout.cmake.in libpng-1.6.39/scripts/genout.cmake.in
---- libpng-1.6.39-orig/scripts/genout.cmake.in	2022-11-20 22:53:23.000000000 +0100
-+++ libpng-1.6.39/scripts/genout.cmake.in	2024-06-09 18:38:38.953706845 +0200
+diff -Nur libpng-1.6.39-orig/scripts/cmake/genout.cmake.in libpng-1.6.39/scripts/cmake/genout.cmake.in
+--- libpng-1.6.39-orig/scripts/cmake/genout.cmake.in	2022-11-20 22:53:23.000000000 +0100
++++ libpng-1.6.39/scripts/cmake/genout.cmake.in	2024-06-09 18:38:38.953706845 +0200
 @@ -14,6 +14,7 @@
  
  set(AWK "@AWK@")

--- a/shared/packages.ini
+++ b/shared/packages.ini
@@ -8,10 +8,10 @@ arguments = "-DZLIB_BUILD_EXAMPLES=OFF"
 anitya_id = 5303
 
 [libpng]
-version = 1.6.39
+version = 1.6.47
 url = "https://download.sourceforge.net/libpng/libpng-${version}.tar.xz"
 arguments = "-DPNG_SHARED=OFF -DPNG_EXECUTABLES=OFF -DPNG_TESTS=OFF"
-anitya_id = 15294
+anitya_id = 1705
 
 [freetype]
 version = 2.13.3
@@ -159,7 +159,7 @@ version_major = 76
 version_minor = 1
 version = ${version_major}-${version_minor}
 _ini_comment = empty on purpose, otherwise polluted by default section
-directory = 
+directory =
 url = https://ci.easyrpg.org/job/icudata/lastSuccessfulBuild/artifact/icudata${version_major}_all.tar.gz
 files = "icudt*.dat"
 anitya_id = 16134

--- a/shared/packages.sh
+++ b/shared/packages.sh
@@ -9,9 +9,9 @@ ZLIB_URL="https://zlib.net/fossils/zlib-1.3.1.tar.gz"
 ZLIB_ARGS="-DZLIB_BUILD_EXAMPLES=OFF"
 ZLIB_DIR="zlib-1.3.1"
 
-LIBPNG_URL="https://download.sourceforge.net/libpng/libpng-1.6.39.tar.xz"
+LIBPNG_URL="https://download.sourceforge.net/libpng/libpng-1.6.47.tar.xz"
 LIBPNG_ARGS="-DPNG_SHARED=OFF -DPNG_EXECUTABLES=OFF -DPNG_TESTS=OFF"
-LIBPNG_DIR="libpng-1.6.39"
+LIBPNG_DIR="libpng-1.6.47"
 
 FREETYPE_URL="https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.xz"
 FREETYPE_ARGS="-DFT_DISABLE_BZIP2=ON -DFT_DISABLE_BROTLI=ON"

--- a/vita/2_build_toolchain.sh
+++ b/vita/2_build_toolchain.sh
@@ -37,6 +37,9 @@ if [ ! -f .patches-applied ]; then
 	)
 
 	# Fix icu build
+	# Remove mutexes (crashes)
+	patch -Np0 < $SCRIPT_DIR/../shared/extra/icu-no-mutex.patch
+	# Vita specific fixes
 	patch -Np0 < $SCRIPT_DIR/icu-vita.patch
 
 	# Disable vita2dlib jpeg dependency


### PR DESCRIPTION
Same issue as for 3DS and Wii

----

After a rebuild we can rerelease the Vita 0.8 VPK :)