### PR TITLE
Apple systems: Disable libpng framework

### DIFF
--- a/ios/2_build_toolchain.sh
+++ b/ios/2_build_toolchain.sh
@@ -61,7 +61,7 @@ function build() {
 	cd "$WORKSPACE"
 
 	install_lib_cmake $ZLIB_DIR $ZLIB_ARGS
-	install_lib_cmake $LIBPNG_DIR $LIBPNG_ARGS
+	install_lib_cmake $LIBPNG_DIR $LIBPNG_ARGS -DPNG_FRAMEWORK=OFF
 	install_lib_cmake $FREETYPE_DIR $FREETYPE_ARGS -DFT_DISABLE_HARFBUZZ=ON
 	install_lib_meson $HARFBUZZ_DIR $HARFBUZZ_ARGS
 	install_lib_cmake $FREETYPE_DIR $FREETYPE_ARGS -DFT_DISABLE_HARFBUZZ=OFF

--- a/macos/2_build_toolchain.sh
+++ b/macos/2_build_toolchain.sh
@@ -61,7 +61,7 @@ function build() {
 	cd "$WORKSPACE"
 
 	install_lib_cmake $ZLIB_DIR $ZLIB_ARGS
-	install_lib_cmake $LIBPNG_DIR $LIBPNG_ARGS
+	install_lib_cmake $LIBPNG_DIR $LIBPNG_ARGS -DPNG_FRAMEWORK=OFF
 	install_lib_cmake $FREETYPE_DIR $FREETYPE_ARGS -DFT_DISABLE_HARFBUZZ=ON
 	install_lib_meson $HARFBUZZ_DIR $HARFBUZZ_ARGS
 	install_lib_cmake $FREETYPE_DIR $FREETYPE_ARGS -DFT_DISABLE_HARFBUZZ=OFF

--- a/tvos/2_build_toolchain.sh
+++ b/tvos/2_build_toolchain.sh
@@ -61,7 +61,7 @@ function build() {
 	cd "$WORKSPACE"
 
 	install_lib_cmake $ZLIB_DIR $ZLIB_ARGS
-	install_lib_cmake $LIBPNG_DIR $LIBPNG_ARGS
+	install_lib_cmake $LIBPNG_DIR $LIBPNG_ARGS -DPNG_FRAMEWORK=OFF
 	install_lib_cmake $FREETYPE_DIR $FREETYPE_ARGS -DFT_DISABLE_HARFBUZZ=ON
 	install_lib_meson $HARFBUZZ_DIR $HARFBUZZ_ARGS
 	install_lib_cmake $FREETYPE_DIR $FREETYPE_ARGS -DFT_DISABLE_HARFBUZZ=OFF


### PR DESCRIPTION
Fixes the build as the framework is not merged into a universal binary (we only use the standalone a files)