### PR TITLE
Windows Editor: Can haz shorter path pls 🥺👉👈

### DIFF
--- a/windows/build_editor.cmd
+++ b/windows/build_editor.cmd
@@ -3,7 +3,7 @@
 call helper\prepare.cmd
 
 :: Build 64-bit libraries
-vcpkg install --triplet x64-windows-static-easyrpgeditor --recurse^
+vcpkg install --triplet x64-windows-eze --recurse^
  zlib[core] expat[core] inih[cpp] nlohmann-json[core] glaze[core]
 
 :: Other dependencies such as Kirigami are built via vcpkg.json and a custom

--- a/windows/helper/prepare.cmd
+++ b/windows/helper/prepare.cmd
@@ -20,6 +20,8 @@ copy ..\helper\windows.cmake scripts\toolchains\windows.cmake
 
 :: add custom editor triplet
 copy ..\helper\x64-windows-static-easyrpgeditor.cmake triplets\x64-windows-static-easyrpgeditor.cmake
+:: shorter version until MAX_PATH limits in the MSVC Linker are fixed (Kirigami paths are extremely long)
+copy ..\helper\x64-windows-static-easyrpgeditor.cmake triplets\x64-windows-eze.cmake
 
 :: Copy custom portfiles
 :: ICU static data file


### PR DESCRIPTION
This is a dumb one:

Even with the MAX_PATH limit removed via the registry key the MSVC Linker still cannot handle them (hardcoded buffer size?).

Linking Kirigami static gives some long paths around 200 characters.

This `windows-x64-static-easyrpgeditor` becomes part of the build path. Shortening it gives 17 characters more to work with. (I don't want to code in "C:\ee" and Jenkins is also unhappy very soon :). With this change it will fit)

I will remove this hack when they fix the linker in 2050 (optimistic guess).