### PR TITLE
Add SDL3

### DIFF
--- a/.github/workflows/stable-compilation.yml
+++ b/.github/workflows/stable-compilation.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Build and Install
         run: |
           cd linux-static
+          sed -i 's/SDL3_ARGS/SDL3_ARGS -DSDL_UNIX_CONSOLE_BUILD=ON/g' ./2_build_toolchain.sh
           ./2_build_toolchain.sh
 
       - name: Cleanup

--- a/android/1_download_library.sh
+++ b/android/1_download_library.sh
@@ -166,6 +166,10 @@ download_and_extract $ICUDATA_URL
 rm -rf $SDL2_DIR
 download_and_extract $SDL2_URL
 
+# SDL3
+rm -rf $SDL3_DIR
+download_and_extract $SDL3_URL
+
 # liblcf
 rm -rf liblcf
 download_liblcf

--- a/android/2_build_toolchain.sh
+++ b/android/2_build_toolchain.sh
@@ -41,6 +41,7 @@ if [ ! -f .patches-applied ]; then
 fi
 
 # Install SDL2
+# FIXME: Remove this when SDL3 migration is done
 function install_lib_sdl {
 	# $1: platform (armeabi-v7a aarch64 x86 x86_x64)
 

--- a/emscripten/1_download_library.sh
+++ b/emscripten/1_download_library.sh
@@ -146,6 +146,10 @@ download_and_extract $ICUDATA_URL
 rm -rf $SDL2_DIR
 download_and_extract $SDL2_URL
 
+# SDL3
+rm -rf $SDL3_DIR
+download_and_extract $SDL3_URL
+
 # liblcf
 rm -rf liblcf
 download_liblcf

--- a/emscripten/1_download_library.sh
+++ b/emscripten/1_download_library.sh
@@ -43,8 +43,8 @@ else
 	touch .emscripten
 
 	# Download and install the latest SDK tools and set up the compiler configuration to point to it.
-	./emsdk install 3.1.74
-	./emsdk activate 3.1.74
+	./emsdk install 5.0.5
+	./emsdk activate 5.0.5
 
 	# Set the current Emscripten path
 	source ./emsdk_env.sh

--- a/emscripten/2_build_toolchain.sh
+++ b/emscripten/2_build_toolchain.sh
@@ -124,6 +124,8 @@ install_lib $SDL2_DIR $SDL2_ARGS --disable-assembly --disable-threads --disable-
 rm -f config.cache
 unset TARGET_HOST
 
+install_lib_cmake $SDL3_DIR $SDL3_ARGS
+
 install_lib_icu_cross
 icu_force_data_install
 

--- a/ios/1_download_library.sh
+++ b/ios/1_download_library.sh
@@ -104,6 +104,10 @@ msg " [3] Downloading platform libraries"
 rm -rf $SDL2_DIR
 download_and_extract $SDL2_URL
 
+# SDL3
+rm -rf $SDL3_DIR
+download_and_extract $SDL3_URL
+
 # liblcf
 rm -rf liblcf
 download_liblcf

--- a/ios/2_build_toolchain.sh
+++ b/ios/2_build_toolchain.sh
@@ -85,6 +85,7 @@ function build() {
 	icu_force_data_install
 	install_lib_liblcf
 	install_lib_cmake $SDL2_DIR $SDL2_ARGS
+	install_lib_cmake $SDL3_DIR $SDL3_ARGS
 }
 
 export MAKEFLAGS="-j${nproc:-2}"

--- a/linux-static/1_download_library.sh
+++ b/linux-static/1_download_library.sh
@@ -102,6 +102,10 @@ download_and_extract $ICUDATA_URL
 rm -rf $SDL2_DIR
 download_and_extract $SDL2_URL
 
+# SDL3
+rm -rf $SDL3_DIR
+download_and_extract $SDL3_URL
+
 # freeimage (only needed for lmu2png tool!)
 rm -rf $FREEIMAGE_DIR
 download_and_extract $FREEIMAGE_URL

--- a/linux-static/2_build_toolchain.sh
+++ b/linux-static/2_build_toolchain.sh
@@ -67,4 +67,5 @@ install_lib_cmake $FMT_DIR $FMT_ARGS
 install_lib $ICU_DIR/source $ICU_ARGS
 install_lib_liblcf
 install_lib $SDL2_DIR $SDL2_ARGS PULSEAUDIO_CFLAGS=-Ixxxdir PULSEAUDIO_LIBS=-lxxxlib
+install_lib_cmake $SDL3_DIR $SDL3_ARGS
 install_lib_cmake $FREEIMAGE_DIR $FREEIMAGE_ARGS

--- a/linux-static/2_build_toolchain.sh
+++ b/linux-static/2_build_toolchain.sh
@@ -67,5 +67,5 @@ install_lib_cmake $FMT_DIR $FMT_ARGS
 install_lib $ICU_DIR/source $ICU_ARGS
 install_lib_liblcf
 install_lib $SDL2_DIR $SDL2_ARGS PULSEAUDIO_CFLAGS=-Ixxxdir PULSEAUDIO_LIBS=-lxxxlib
-install_lib_cmake $SDL3_DIR $SDL3_ARGS
+install_lib_cmake $SDL3_DIR $SDL3_ARGS -DSDL_X11_XSCRNSAVER=OFF -DSDL_X11_XTEST=OFF
 install_lib_cmake $FREEIMAGE_DIR $FREEIMAGE_ARGS

--- a/linux-static/2_build_toolchain.sh
+++ b/linux-static/2_build_toolchain.sh
@@ -67,5 +67,10 @@ install_lib_cmake $FMT_DIR $FMT_ARGS
 install_lib $ICU_DIR/source $ICU_ARGS
 install_lib_liblcf
 install_lib $SDL2_DIR $SDL2_ARGS PULSEAUDIO_CFLAGS=-Ixxxdir PULSEAUDIO_LIBS=-lxxxlib
-install_lib_cmake $SDL3_DIR $SDL3_ARGS -DSDL_X11_XSCRNSAVER=OFF -DSDL_X11_XTEST=OFF
 install_lib_cmake $FREEIMAGE_DIR $FREEIMAGE_ARGS
+
+# Ensure that SDL3 finds the system libraries
+# They are loaded dynamically and don't add hard dependencies
+unset PKG_CONFIG_PATH
+unset PKG_CONFIG_LIBDIR
+install_lib_cmake $SDL3_DIR $SDL3_ARGS -DSDL_X11_XSCRNSAVER=OFF -DSDL_X11_XTEST=OFF

--- a/macos/1_download_library.sh
+++ b/macos/1_download_library.sh
@@ -104,6 +104,10 @@ msg " [3] Downloading platform libraries"
 rm -rf $SDL2_DIR
 download_and_extract $SDL2_URL
 
+# SDL3
+rm -rf $SDL3_DIR
+download_and_extract $SDL3_URL
+
 # freeimage (only needed for lmu2png tool!)
 rm -rf $FREEIMAGE_DIR
 download_and_extract $FREEIMAGE_URL

--- a/macos/2_build_toolchain.sh
+++ b/macos/2_build_toolchain.sh
@@ -84,6 +84,7 @@ function build() {
 	install_lib_icu_cross
 	icu_force_data_install
 	install_lib $SDL2_DIR $SDL2_ARGS --disable-assembly
+	install_lib_cmake $SDL3_DIR $SDL3_ARGS
 	install_lib_cmake $FREEIMAGE_DIR $FREEIMAGE_ARGS
 	install_lib_liblcf
 }

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -404,7 +404,7 @@ function cleanup {
 	rm -rf zlib-*/ libpng-*/ freetype-*/ harfbuzz-*/ pixman-*/ expat-*/ libogg-*/ \
 	libvorbis-*/ tremor-*/ mpg123-*/ libsndfile-*/ libxmp-lite-*/ speexdsp-*/ \
 	libsamplerate-*/ wildmidi-*/ opus-*/ opusfile-*/ icu/ icu-native/ icu-cross/ \
-	SDL2-*/ SDL2_image-*/ fmt-*/ FluidLite-*/ fluidsynth-*/ json-*/ inih-*/ \
+	SDL2-*/ SDL3-*/ fmt-*/ FluidLite-*/ fluidsynth-*/ json-*/ inih-*/ \
 	lhasa-*/ freeimage-* liblcf/
 	rm -f *.zip *.bz2 *.gz *.xz *.tgz icudt* .patches-applied config.cache meson-cross.txt
 	rm -rf sbin/ share/

--- a/shared/packages.ini
+++ b/shared/packages.ini
@@ -174,6 +174,7 @@ anitya_id = 4779
 [SDL3]
 version = 3.4.4
 url = "https://libsdl.org/release/SDL3-${version}.tar.gz"
+arguments = "-DSDL_TEST_LIBRARY=OFF -DSDL_EXAMPLES=OFF"
 anitya_id = 375746
 
 [freeimage]

--- a/shared/packages.ini
+++ b/shared/packages.ini
@@ -160,19 +160,24 @@ version_major = 78
 version_minor = 2
 version = ${version_major}.${version_minor}
 _ini_comment = empty on purpose, otherwise polluted by default section
-directory = 
+directory =
 url = https://ci.easyrpg.org/job/icudata/lastSuccessfulBuild/artifact/icudata${version_major}_all.tar.gz
 files = "icudt*.dat"
 anitya_id = 379847
 
 [SDL2]
+comment = Remove when SDL3 migration is done
 version = 2.32.10
 url = "https://libsdl.org/release/SDL2-${version}.tar.gz"
 anitya_id = 4779
+
+[SDL3]
+version = 3.4.4
+url = "https://libsdl.org/release/SDL3-${version}.tar.gz"
+anitya_id = 375746
 
 [freeimage]
 comment = 3.18.0, only needed for lmu2png tool
 version = d82954e4adcb6c1b223bd3cb2e953b6bbf54dfcd
 url = "https://github.com/carstene1ns/freeimage-easyrpg/archive/${version}.zip"
 directory = "freeimage-easyrpg-${version}"
-

--- a/shared/packages.sh
+++ b/shared/packages.sh
@@ -110,6 +110,7 @@ SDL2_URL="https://libsdl.org/release/SDL2-2.32.10.tar.gz"
 SDL2_DIR="SDL2-2.32.10"
 
 SDL3_URL="https://libsdl.org/release/SDL3-3.4.4.tar.gz"
+SDL3_ARGS="-DSDL_TEST_LIBRARY=OFF -DSDL_EXAMPLES=OFF"
 SDL3_DIR="SDL3-3.4.4"
 
 # 3.18.0, only needed for lmu2png tool

--- a/shared/packages.sh
+++ b/shared/packages.sh
@@ -105,8 +105,12 @@ ICU_ARGS="--enable-strict=no --disable-tests --disable-samples \
 ICUDATA_URL=https://ci.easyrpg.org/job/icudata/lastSuccessfulBuild/artifact/icudata78_all.tar.gz
 ICUDATA_FILES="icudt*.dat"
 
+# Remove when SDL3 migration is done
 SDL2_URL="https://libsdl.org/release/SDL2-2.32.10.tar.gz"
 SDL2_DIR="SDL2-2.32.10"
+
+SDL3_URL="https://libsdl.org/release/SDL3-3.4.4.tar.gz"
+SDL3_DIR="SDL3-3.4.4"
 
 # 3.18.0, only needed for lmu2png tool
 FREEIMAGE_URL="https://github.com/carstene1ns/freeimage-easyrpg/archive/d82954e4adcb6c1b223bd3cb2e953b6bbf54dfcd.zip"

--- a/tvos/1_download_library.sh
+++ b/tvos/1_download_library.sh
@@ -104,6 +104,10 @@ msg " [3] Downloading platform libraries"
 rm -rf $SDL2_DIR
 download_and_extract $SDL2_URL
 
+# SDL3
+rm -rf $SDL3_DIR
+download_and_extract $SDL3_URL
+
 # liblcf
 rm -rf liblcf
 download_liblcf

--- a/tvos/2_build_toolchain.sh
+++ b/tvos/2_build_toolchain.sh
@@ -85,6 +85,7 @@ function build() {
 	icu_force_data_install
 	install_lib_liblcf
 	install_lib_cmake $SDL2_DIR $SDL2_ARGS
+	install_lib_cmake $SDL3_DIR $SDL3_ARGS
 }
 
 export MAKEFLAGS="-j${nproc:-2}"

--- a/windows/build.cmd
+++ b/windows/build.cmd
@@ -10,7 +10,7 @@ vcpkg install --triplet x86-windows-static --recurse^
  libvorbis[core] libsndfile[core] wildmidi[core] libxmp[core]^
  speexdsp[core] mpg123[core] opusfile[core] fluidsynth-easyrpg[core]^
  inih[cpp] lhasa-easyrpg[core]^
- sdl2[core] icu-easyrpg[core] nlohmann-json[core] fmt[core]
+ sdl2[core] sdl3[core] icu-easyrpg[core] nlohmann-json[core] fmt[core]
 
 :: Build 64-bit libraries
 vcpkg install --triplet x64-windows-static --recurse^
@@ -18,4 +18,4 @@ vcpkg install --triplet x64-windows-static --recurse^
  libvorbis[core] libsndfile[core] wildmidi[core] libxmp[core]^
  speexdsp[core] mpg123[core] opusfile[core] fluidsynth-easyrpg[core]^
  inih[cpp] lhasa-easyrpg[core]^
- sdl2[core] icu-easyrpg[core] nlohmann-json[core] fmt[core]
+ sdl2[core] sdl3[core] icu-easyrpg[core] nlohmann-json[core] fmt[core]


### PR DESCRIPTION
To not break too much stuff I suggest to do this in multiple steps:

1. Add SDL3 and keep SDL2 for now. They dont have any file conflicts so this is safe to do
2. Change the default in the Player to SDL3
 - For now keep emscripten (canvas scale issues) and Android (crashes) on SDL2
3. When everything is ported remove SDL2 in another PR to buildscripts